### PR TITLE
Use empty user's name and email if git doesn't know them

### DIFF
--- a/src/main/git-elegant-configure
+++ b/src/main/git-elegant-configure
@@ -6,11 +6,11 @@ _core_comment_char_default="|"
 _core_comment_char_message="commit message won't start with"
 
 _user_name_key="user.name"
-_user_name_default=$(git config "$_user_name_key")
+_user_name_default=$(git config "$_user_name_key" || echo '')
 _user_name_message="your user name"
 
 _user_email_key="user.email"
-_user_email_default=$(git config "$_user_email_key")
+_user_email_default=$(git config "$_user_email_key" || echo '')
 _user_email_message="your user email"
 
 _apply_whitespace_key="apply.whitespace"

--- a/src/test/git-elegant-configure.bats
+++ b/src/test/git-elegant-configure.bats
@@ -67,3 +67,11 @@ teardown() {
     [ "${lines[12]}" = "whitespace issues on patching [fix]: " ]
     [ ${#lines[@]} -eq 16 ]
 }
+
+@test "'configure': command works if both 'user.name' and 'user.email' are absent" {
+    # move to the directory without the ".git/"
+    cd /tmp
+    # force "11" exit code - means all internal vars are initialised (including 'user.name' and 'user.email')
+    check git-elegant configure
+    [ "$status" -eq 11 ]
+}


### PR DESCRIPTION
For the new git installations, the "user.name" and "user.email" settings
may not be configured. As the result, if a user tries to use "git
elegant configure ..." directly or as part of another command ("init"
etc.), it leads to a breaking of "configure" execution since a default setting can't be read.

As a solution, an empty value will be used by default in the case of the
"user.name" and "user.email" aren't configured on a global level.

Closes #110