### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+mkdocs:
+  configuration: mkdocs.yml
+formats: all
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,2 +1,0 @@
-elegant-git.extsoft.pro
-

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,0 @@
-theme: jekyll-theme-tactile
-


### PR DESCRIPTION
.readthedocs.yml stores relevant configuration for building the
documentation.

Also, configuration of Github Pages is removed.