### PR TITLE
Add `start-work` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 `git elegant <command>` where `<command>` is one of
 
-- `feature`
+- `start-work`
 - `pull`
 - `push`
 - `push-after-rebase`
@@ -13,8 +13,21 @@
 - `check`
 - `save`
 
-# `feature`
-Creates a new branch based on `master`. If there are some uncommitted changes, they will be moved to the new branch.
+# `start-work`
+Creates a new local branch based on latest version of `master`. If there are some uncommitted
+changes, they will be moved to the new branch.
+
+```bash
+usage: git elegant start-work <branch-name>
+```
+
+A sequence of original `git` commands:
+```bash
+git checkout master
+git fetch --tags
+git pull
+git checkout -b <branch-name>
+```
 
 # `pull`
 Downloads new updates for a local branch.

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -41,9 +41,10 @@ __mmn() {
 MASTER="master"
 RMASTER="origin/master"
 
-_validate() {
-    if [ -z "$1" ]; then
-        __rm "$2 is not set"
+_error-if-empty() {
+    # _error-if-empty <a value to check> <error message>
+    if [[ -z "$1" ]]; then
+        __rm "$2"
         exit -1
     fi
 }

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -2,7 +2,7 @@
 set -e
 
 default() {
-    _validate "$1" "Cloneable URL"
+    _error-if-empty "$1" "Cloneable URL is not set."
     boxtee git clone "$1"
     cd $(basename -s .git $1)
     git elegant configure-repository

--- a/libexec/git-elegant-commands
+++ b/libexec/git-elegant-commands
@@ -2,7 +2,7 @@
 set -e
 
 default() {
-    echo "feature"
+    echo "start-work"
     echo "pull"
     echo "push"
     echo "push-after-rebase"

--- a/libexec/git-elegant-start-work
+++ b/libexec/git-elegant-start-work
@@ -2,7 +2,7 @@
 set -e
 
 default() {
-    _validate "$1" "Feature name"
+    _error-if-empty "$1" "Please give a name for the new branch."
     status=$(boxtee git stash save elegant-git)
     git elegant pull $MASTER
     boxtee git checkout -b "$1"

--- a/tests/git-elegant-commands.bats
+++ b/tests/git-elegant-commands.bats
@@ -9,7 +9,7 @@ teardown() {
 
 @test "'commands': print all available commands" {
   check git-elegant commands
-  [ "${lines[0]}" = "feature" ]
+  [ "${lines[0]}" = "start-work" ]
   [ "${lines[1]}" = "pull" ]
   [ "${lines[2]}" = "push" ]
   [ "${lines[3]}" = "push-after-rebase" ]

--- a/tests/git-elegant-start-work.bats
+++ b/tests/git-elegant-start-work.bats
@@ -13,39 +13,39 @@ teardown() {
     clean-fake
 }
 
-@test "'feature': branch with given name is created successfully" {
-  check git-elegant feature test-feature
+@test "'start-work': branch with given name is created successfully" {
+  check git-elegant start-work test-feature
   [ "$status" -eq 0 ]
 }
 
-@test "'feature': exit code is 255 when branch name isn't set" {
-  check git-elegant feature
+@test "'start-work': exit code is 255 when branch name isn't set" {
+  check git-elegant start-work
   [ "$status" -eq 255 ]
 }
 
-@test "'feature': print error message when branch name isn't set" {
-  check git-elegant feature
-  [[ "${lines[0]}" =~ "Feature name is not set" ]]
+@test "'start-work': print error message when branch name isn't set" {
+  check git-elegant start-work
+  [[ "${lines[0]}" =~ "Please give a name for the new branch." ]]
 }
 
-@test "'feature': use stash for available changes" {
+@test "'start-work': use stash for available changes" {
   fake-pass git "stash save elegant-git" "Saved working directory"
   fake-pass git "stash apply stash^{/elegant-git}"
   fake-pass git "stash drop stash@{0}"
-  check git-elegant feature test-feature
+  check git-elegant start-work test-feature
   [ "$status" -eq 0 ]
 }
 
-@test "'feature': ignore stash if there are no changes" {
+@test "'start-work': ignore stash if there are no changes" {
   fake-pass git "stash save elegant-git" "No local changes to save"
-  check git-elegant feature test-feature
+  check git-elegant start-work test-feature
   [ "$status" -eq 0 ]
 }
 
-@test "'feature': exit code is 100 when stash wasn't applied" {
+@test "'start-work': exit code is 100 when stash wasn't applied" {
   fake-pass git "stash save elegant-git" "Saved working directory"
   fake-pass git "stash apply stash^{/elegant-git}"
   fake-fail git "stash drop stash@{0}"
-  check git-elegant feature test-feature
+  check git-elegant start-work test-feature
   [ "$status" -eq 100 ]
 }


### PR DESCRIPTION
The `start-work` command is a former `git elegant feature`command. It's
renamed as this name is declarative one. Also, documentation is updated
updated with alternative git commands.

`_validate` is renamed to `_error-if-empty` which is unambiguous name.

#115