### PR TITLE
Propagate user arguments to libexec scripts

### DIFF
--- a/bin/git-elegant
+++ b/bin/git-elegant
@@ -11,4 +11,4 @@ while [[ -h "$SOURCE" ]]; do
 done
 INSTALLATION="$(cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd)"
 
-exec "${INSTALLATION}/../libexec/git-elegant"
+exec "${INSTALLATION}/../libexec/git-elegant" $@

--- a/quality-pipeline.bash
+++ b/quality-pipeline.bash
@@ -13,7 +13,12 @@ fail() {
 
 pipeline() {
     bats --tap tests                                  || fail "Unit tests are failed."
-    ./install.bash /usr/local src && git elegant help || fail "Installation test is failed."
+    (
+        echo "Installation...."
+        ./install.bash /usr/local src
+        echo "'Unknown command' testing..."
+        git elegant unknown-command | grep "Unknown command: git elegant unknown-command"
+    )                                                 || fail "Installation test is failed."
     mkdocs build --clean --strict                     || fail "Unable to build the documentation."
     pdd --exclude=.idea/**/* \
         --exclude=site/**/* \


### PR DESCRIPTION
`bin/git-elegant` is the main entry script which has to pass all
arguments to `libexec/git-elegant` script, otherwise, a help message
will be printed and there is no chance to call any other command -
in other words, there is a bug. Since this change, all arguments will be
propagated to right place and "Elegant git" should work as expected.

Testing approach is based on invocation an unknown command after the
installation. This initiates the real call to "Elegant git" logic. So,
the arguments propagation logic is tested. Previous solution (invoke
`help` command) is not a good choice as help message can be shown in
many cases (untrustworthy results of testing).