### PR TITLE
Add more mandatory configurations to `acquire-repository` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,12 +24,31 @@ A sequence of original `git` commands:
 ```bash
 git config --local user.name {provided name}
 git config --local user.email {provided email}
+git config --local core.editor {provided editor}
 # "|" char starts non-message lines while writing commit message
 git config --local core.commentChar |
 # Remove whitespaces when apply a patch
 git config --local apply.whitespace fix
 # Shortening Elegant git commands for work-related commands
 git config --local "alias.<command>" "elegant <command>"
+# Keeping up-to-date with both branches and tags on the remote
+git config --local fetch.prune true
+git config --local fetch.pruneTags true
+# Rebase local changes while puling remotes refs
+git config --local fetch.prune true
+git config --local fetch.pruneTags
+# Line ending configuration
+## on MAC or Linux
+git config --local core.autocrlf input
+## on Windows
+git config --local core.autocrlf true
+# Always rebase when pull
+git config --local pull.rebase true
+# Always autostash if rebase
+git config --local rebase.autoStash true
+# Specify an external helper to be called when a username 
+# or password credential is needed (MAC only)
+git config --local credential.helper osxkeychain
 ```
 
 # `clone-repository`
@@ -113,7 +132,7 @@ usage: git elegant accept-work <remote-branch>
 ```
 A sequence of original `git` commands:
 ```bash
-git fetch --all --tags --prune
+git fetch --all --tags
 git checkout -b eg origin/master
 git rebase --merge --strategy ff-only <remote-branch-name>
 git checkout master

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -5,7 +5,7 @@ set -e
 default() {
     _error-if-empty "${1}" "Please give a name of remote branch (like 'origin/123')."
     local WORK_BRANCH="eg"
-    boxtee git fetch --all --tags --prune
+    boxtee git fetch --all --tags
     boxtee git checkout -b ${WORK_BRANCH} ${RMASTER}
     boxtee git rebase --merge --strategy ff-only ${1}
     # @todo #137 Alternative flows of `accept-work`

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -1,19 +1,37 @@
 #!/usr/bin/env bash
-#set -e
+set -e
 
 _user_name_key="user.name"
-_user_name_default=$(git config "$_user_name_key" || echo '')
+_user_name_default=$(git config ${_user_name_key} || echo "")
 _user_name_message="What is your user name?"
 
 _user_email_key="user.email"
-_user_email_default=$(git config "$_user_email_key" || echo '')
+_user_email_default=$(git config ${_user_email_key} || echo "")
 _user_email_message="What is your user email?"
 
-_core_comment_char_key="core.commentChar"
-_core_comment_char_default="|"
+_core_editor_key="core.editor"
+_core_editor_default=$(git config "${_core_editor_key}" || echo "vim")
+_core_editor_message="Please specify a command to start the editor."
 
-_apply_whitespace_key="apply.whitespace"
-_apply_whitespace_default="fix"
+
+# mandatory
+_core_comment=("core.commentChar" "|")
+_apply_whitespace=("apply.whitespace" "fix")
+_fetch_prune=("fetch.prune" "true")
+_fetch_pruneTags=("fetch.pruneTags" "true")
+## Line endings
+## See https://help.github.com/en/articles/configuring-git-to-handle-line-endings
+### MAC/Linux
+_core_autocrlf_darwinlinux=("core.autocrlf" "input")
+### Windows
+_core_autocrlf_windows=("core.autocrlf" "true")
+## Pull
+_pull_rebase=("pull.rebase" "true")
+## Rebase
+_rebase_autoStash=("rebase.autoStash" "true")
+## Credentials, MAC only
+_credential_helper_darwin=("credential.helper" "osxkeychain")
+
 
 __ask_question() {
     # usage: __ask_options <prefix>
@@ -28,6 +46,7 @@ __ask_question() {
 }
 
 __interactive-configuration() {
+    box "Interactive configuration. Please hit enter if you wish {default value}."
     FUNCTIONS=$@
     for f in ${FUNCTIONS[@]}; do
         unset ANSWER
@@ -41,11 +60,19 @@ __interactive-configuration() {
 }
 
 __mandatory-configuration() {
-    FUNCTIONS=$@
-    for config in ${FUNCTIONS[@]}; do
-        key=$(eval "echo -n \$${config}_key")
-        value=$(eval "echo -n \$${config}_default")
-        boxtee git config --local ${key} ${value}
+    # usage: __mandatory-configuration <name of array> ...
+    for config in ${@}; do
+        local os=$(uname -s)
+        if [[ "Darwin Linux" =~ "${os}" ]]; then
+            [[ "${config}" =~ "windows" ]] && continue
+            [[ "${os}" = "Darwin" && ! "${config}" =~ "darwin" && "${config}" =~ "linux" ]] && continue
+            [[ "${os}" = "Linux" && ! "${config}" =~ "linux"  && "${config}" =~ "darwin" ]] && continue
+        fi
+        if [[ "Windows" = "${os}" ]]; then
+            [[ "${config}" =~ "darwin" || "${config}" =~ "linux" ]] && continue
+        fi
+        local data=($(eval "echo -n \${${config}[@]}"))
+        boxtee git config --local ${data[0]} ${data[1]}
     done
 }
 __remove-old-aliases() {
@@ -69,8 +96,11 @@ __aliases-configuration() {
 }
 
 default() {
-      __interactive-configuration _user_name _user_email
-      __mandatory-configuration _core_comment_char _apply_whitespace
+      __interactive-configuration _user_name _user_email _core_editor
+      __mandatory-configuration \
+        _core_comment _apply_whitespace _fetch_prune _fetch_pruneTags \
+        _core_autocrlf_darwinlinux _core_autocrlf_windows _pull_rebase \
+        _rebase_autoStash _credential_helper_darwin
       __remove-old-aliases
       __aliases-configuration "pull" "clear-local" $(git elegant commands | grep work)
 }

--- a/tests/addons-git.bash
+++ b/tests/addons-git.bash
@@ -11,6 +11,7 @@ init-repo() {
         testtee git init
         testtee git config --local user.email "\"elegant-git@example.com\""
         testtee git config --local user.name "\"Elegant Git\""
+        testtee git config --local core.editor "\"edi\""
         testtee touch $FILE_TO_MODIFY
         testtee git add .
         testtee git commit -m "\"Add $FILE_TO_MODIFY\""

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -8,7 +8,7 @@ teardown() {
 }
 
 @test "'accept-work': a work is accepted successfully for given remote branch" {
-    fake-pass git "fetch --all --tags --prune"
+    fake-pass git "fetch --all --tags"
     fake-pass git "checkout -b eg origin/master"
     fake-pass git "rebase --merge --strategy ff-only origin/work"
     fake-pass git "checkout master"

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -5,11 +5,6 @@ load addons-read
 load addons-fake
 load addons-git
 
-fake-preconditions() {
-    fake-pass git "config user.name" "UserName"
-    fake-pass git "config user.email" "UserEmail"
-
-}
 setup() {
     init-repo
 }
@@ -21,20 +16,62 @@ teardown() {
 
 @test "'acquire-repository': all configurations work as expected" {
     check git-elegant acquire-repository
-    [[ ${#lines[@]} -eq 35 ]]
     [[ "${status}" -eq 0 ]]
 }
 
 @test "'acquire-repository': interactive configuration works as expected" {
     check git-elegant acquire-repository
     [[ "${lines[@]}" =~ "What is your user name? {Elegant Git}: " ]]
+    [[ "${lines[@]}" =~ "== git config --local user.name Elegant Git ==" ]]
     [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
+    [[ "${lines[@]}" =~ "== git config --local user.email elegant-git@example.com ==" ]]
+    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {edi}: " ]]
+    [[ "${lines[@]}" =~ "== git config --local core.editor edi ==" ]]
 }
 
-@test "'acquire-repository': mandatory configuration works as expected" {
+@test "'acquire-repository': mandatory configuration works as expected on Windows" {
+    fake-pass uname -s Windows
     check git-elegant acquire-repository
     [[ "${lines[@]}" =~ "== git config --local core.commentChar | ==" ]]
     [[ "${lines[@]}" =~ "== git config --local apply.whitespace fix ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.prune true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    # negative checks are used instead of checking commands size
+    [[ ! "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
+    [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
+}
+
+@test "'acquire-repository': mandatory configuration works as expected on Linux" {
+    fake-pass uname -s Linux
+    check git-elegant acquire-repository
+    [[ "${lines[@]}" =~ "== git config --local core.commentChar | ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local apply.whitespace fix ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.prune true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    # negative checks are used instead of checking commands size
+    [[ ! "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
+    [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]
+}
+
+@test "'acquire-repository': mandatory configuration works as expected on Darwin" {
+    fake-pass uname -s Darwin
+    check git-elegant acquire-repository
+    [[ "${lines[@]}" =~ "== git config --local core.commentChar | ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local apply.whitespace fix ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.prune true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
+    # negative checks are used instead of checking commands size
+    [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]
 }
 
 @test "'acquire-repository': aliases configuration works as expected" {


### PR DESCRIPTION
The added configuration options are required for good work of
Elegant git. Also, they are platform-specific which make the tool
a cross-platform one.