### PR TITLE
Reapply commits on top of `origin/master` when `accept-work`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -136,12 +136,12 @@ usage: git elegant accept-work <remote-branch>
 A sequence of original `git` commands:
 ```bash
 git fetch --all --tags
-git checkout -b eg origin/master
-git rebase --merge --strategy ff-only <remote-branch-name>
+git checkout -b __eg <remote-branch-name>
+git rebase origin/master
 git checkout master
-git merge --ff-only eg
+git merge --ff-only __eg
 git push origin master:master
-git branch -d eg
+git branch -d __eg
 git push origin --delete <remote-branch-name>
 ```
 

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -3,11 +3,12 @@ set -e
 
 
 default() {
-    _error-if-empty "${1}" "Please give a name of remote branch (like 'origin/123')."
-    local WORK_BRANCH="eg"
+    local WORK=${1}
+    _error-if-empty "${WORK}" "Please give a name of remote branch (like 'origin/123')."
+    local WORK_BRANCH="__eg"
     boxtee git fetch --all --tags
-    boxtee git checkout -b ${WORK_BRANCH} ${RMASTER}
-    boxtee git rebase --merge --strategy ff-only ${1}
+    boxtee git checkout -b ${WORK_BRANCH} ${WORK}
+    boxtee git rebase ${RMASTER}
     # @todo #137 Alternative flows of `accept-work`
     #  If this command is executed with `${WORK_BRANCH}` and
     #  1. `git rebase` is in progress, it has to run `git rebase --continue` prior working with

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats -ex
+#!/usr/bin/env bats
 
 load addons-common
 load addons-fake
@@ -9,20 +9,20 @@ teardown() {
 
 @test "'accept-work': a work is accepted successfully for given remote branch" {
     fake-pass git "fetch --all --tags"
-    fake-pass git "checkout -b eg origin/master"
-    fake-pass git "rebase --merge --strategy ff-only origin/work"
+    fake-pass git "checkout -b __eg origin/work"
+    fake-pass git "rebase origin/master"
     fake-pass git "checkout master"
-    fake-pass git "merge --ff-only eg"
+    fake-pass git "merge --ff-only __eg"
     fake-pass git "push origin master:master"
-    fake-pass git "branch --delete eg"
+    fake-pass git "branch --delete __eg"
     fake-pass git "push origin --delete work"
     check git-elegant accept-work origin/work
-    [ "$status" -eq 0 ]
+    [[ "$status" -eq 0 ]]
 }
 
 @test "'accept-work': exit code is 45 when remote branch name isn't set" {
     check git-elegant accept-work
-    [ "$status" -eq 45 ]
+    [[ "$status" -eq 45 ]]
 }
 
 @test "'accept-work': print error message when remote branch name isn't set" {


### PR DESCRIPTION
The update enforces usage of remote work branch as a base for rebasing
latest remote master. This change solves a problem where
the work branch is obsolete (doesn't have some other master commits).