### PR TITLE
Make `accept-work` completion working correctly

### DIFF
--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -16,9 +16,8 @@ _git_elegant() {
             COMPREPLY=( $(compgen -W "${data}" ${cur}) )
             return 0 ;;
         accept-work)
-            git fetch --all
             COMPREPLY=(
-                $(compgen -W "$(git branch --remotes --list)" -- ${cur})
+                $(compgen -W "$(git fetch --all &>/dev/null; git branch --remotes --list)" -- ${cur})
             )
             return 0 ;;
         *)


### PR DESCRIPTION
The fetch operation will be performed within the same BASH context where
git shows branches. This has to solve problem with wrong completion.