### PR TITLE
Make `--force` removal for local WORK_BRANCH

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -141,7 +141,7 @@ git rebase origin/master
 git checkout master
 git merge --ff-only __eg
 git push origin master:master
-git branch -d __eg
+git branch --delete --force __eg
 git push origin --delete <remote-branch-name>
 ```
 

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -18,6 +18,6 @@ default() {
     boxtee git checkout ${MASTER}
     boxtee git merge --ff-only ${WORK_BRANCH}
     boxtee git push ${REMOTE_NAME} ${MASTER}:${MASTER}
-    boxtee git branch --delete ${WORK_BRANCH}
+    boxtee git branch --delete --force ${WORK_BRANCH}
     boxtee git push ${REMOTE_NAME} --delete $(echo "${1}" | sed -e "s|${REMOTE_NAME}/||")
 }

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -14,7 +14,7 @@ teardown() {
     fake-pass git "checkout master"
     fake-pass git "merge --ff-only __eg"
     fake-pass git "push origin master:master"
-    fake-pass git "branch --delete __eg"
+    fake-pass git "branch --delete --force __eg"
     fake-pass git "push origin --delete work"
     check git-elegant accept-work origin/work
     [[ "$status" -eq 0 ]]


### PR DESCRIPTION
`--delete` doesn't guarantee removing of WORK_BRANCH if a rebase is
applied. It's happens since remote branch has other history then local
one. That's why, if a rebase is done, it's safe to remove local branch
with `--force` option.