### PR TITLE
Don't fetch branches while completing `accept-work`

### DIFF
--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -17,7 +17,7 @@ _git_elegant() {
             return 0 ;;
         accept-work)
             COMPREPLY=(
-                $(compgen -W "$(git fetch --all &>/dev/null; git branch --remotes --list)" -- ${cur})
+                $(compgen -W "$(git branch --remotes --list)" -- ${cur})
             )
             return 0 ;;
         *)


### PR DESCRIPTION
The fetching is removed as it works too long. As the alternative,
a user can fetch fresh updates by himself/herself.