### PR TITLE
Disallow `save-work` for local `master` branch

### DIFF
--- a/libexec/git-elegant-save-work
+++ b/libexec/git-elegant-save-work
@@ -2,6 +2,12 @@
 set -e
 
 default(){
+    local BRANCH=$(__branches 'git branch | grep \*')
+    if [[ "$BRANCH" == "master" ]]; then
+        box "No commits to 'master' branch. Please read more on ${__site}"
+        box "Try 'git elegant start-work' prior to retrying this command."
+        exit 42
+    fi
     boxtee git add --interactive
     boxtee git diff --cached --check
     boxtee git commit

--- a/tests/addons-git.bash
+++ b/tests/addons-git.bash
@@ -29,6 +29,14 @@ add-st-change(){
     testtee git add $FILE_TO_MODIFY
 }
 
+gitrepo() {
+    # execute given arguments on real git repo
+    # usage: gitrepo <command and arguments>
+    testtee cd ${GIT_REPO_DIR}
+    testtee eval $@
+    testtee cd -
+}
+
 clean-git() {
     if [ -d "$GIT_REPO_DIR" ]; then
         rm -rf "$GIT_REPO_DIR"

--- a/tests/git-elegant-save-work.bats
+++ b/tests/git-elegant-save-work.bats
@@ -3,19 +3,29 @@
 load addons-common
 load addons-fake
 load addons-read
+load addons-git
 
+setup() {
+    init-repo
+}
 
 teardown() {
     clean-fake
+    clean-git
 }
 
-setup() {
+@test "'save-work': command works as expected for non-master branch" {
     fake-pass git "add --interactive"
     fake-pass git "diff --cached --check"
-    fake-pass git commit
+    fake-pass git "commit"
+    gitrepo git checkout -b test
+    check git-elegant save-work
+    [[ "${status}" -eq 0 ]]
 }
 
-@test "'save-work': command is available" {
+@test "'save-work': exit code is 42 when current local branch is master" {
     check git-elegant save-work
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 42 ]]
+    [[ "${lines[@]}" =~ "== No commits to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
+    [[ "${lines[@]}" =~ "== Try 'git elegant start-work' prior to retrying this command. ==" ]]
 }


### PR DESCRIPTION
According to Elegant Git philosophy, changes have to be applied for
non-master branches only. It's relevant for commits too.

Add `gitrepo` command which allow executing commands on real git
repository for unit testing.