### PR TITLE
Warn about a global alias instead of trying removing it

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -52,6 +52,10 @@ git config --local rebase.autoStash true
 # Specify an external helper to be called when a username 
 # or password credential is needed (MAC only)
 git config --local credential.helper osxkeychain
+# Remove local aliases which contain Elegant Git commands
+git config --local --unset <alias>
+# Add aliases for current commands
+git config --local alias.<command> "elegant <command>"
 ```
 
 # `clone-repository`

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -78,10 +78,13 @@ __mandatory-configuration() {
 __remove-old-aliases() {
     old_aliases=($(git config --get-regexp ^alias\. | grep "elegant " | cut -f 1 -d " "))
     if [[ ${#old_aliases[@]} -ne 0 ]]; then
+        local counter=0
         for old in ${old_aliases[@]}; do
-            git config --local --unset ${old}
+            boxtee git config --local --unset ${old} &&
+            counter=$((counter+1)) ||
+            box "Non-local alias! Remove it if needed using 'git config --global --unset ${old}'"
         done
-        box "${#old_aliases[@]} git aliases were removed that contained 'elegant git' reference."
+        box "${counter} git aliases were removed that contained 'elegant git' reference."
     else
         box "There are no git aliases which contain 'elegant git' reference."
     fi

--- a/tests/addons-git.bash
+++ b/tests/addons-git.bash
@@ -33,7 +33,7 @@ gitrepo() {
     # execute given arguments on real git repo
     # usage: gitrepo <command and arguments>
     testtee cd ${GIT_REPO_DIR}
-    testtee eval $@
+    testtee $@
     testtee cd -
 }
 

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -82,12 +82,21 @@ teardown() {
     [[ "${lines[@]}" =~ "== git config --local alias.accept-work elegant accept-work ==" ]]
 }
 
-@test "'acquire-repository': removing existing git aliases works as expected when aliases available" {
-    testtee git config --local "alias.aaa" "\"elegant aaa\""
-    testtee git config --local "alias.bbb" "\"elegant bbb\""
+@test "'acquire-repository': local aliases are removed as expected" {
+    gitrepo git config --local "alias.aaa" "\"elegant aaa\""
+    gitrepo git config --local "alias.bbb" "\"elegant bbb\""
     check git-elegant acquire-repository
     [[ "$status" -eq 0 ]]
     [[ "${lines[@]}" =~ "== 2 git aliases were removed that contained 'elegant git' reference. ==" ]]
+}
+
+@test "'acquire-repository': global aliases aren't removed" {
+    gitrepo git config --global "alias.glb" "\"elegant glb\""
+    check git-elegant acquire-repository
+    gitrepo git config --global --unset "alias.glb"
+    [[ "$status" -eq 0 ]]
+    [[ "${lines[@]}" =~ "== Non-local alias! Remove it if needed using 'git config --global --unset alias.glb' ==" ]]
+    [[ "${lines[@]}" =~ "== 0 git aliases were removed that contained 'elegant git' reference. ==" ]]
 }
 
 @test "'acquire-repository': removing existing git aliases works as expected when aliases are absent" {


### PR DESCRIPTION
Now, aliases won't be created in case if there is global alias related
to Elegant Git. This is because, removal fails as `git config --local
--unset` provides non-zero exit code. As a result, new aliases won't be
created.

The logic is updated to the followign state:
If `acquire-reposiroty` is executed, we need upgrade current aliases by
- removing local ones, and
- adding new ones, and
- notify about global ones if they are present