### PR TITLE
Newer autostash when rebase

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,8 +47,8 @@ git config --local core.autocrlf input
 git config --local core.autocrlf true
 # Always rebase when pull
 git config --local pull.rebase true
-# Always autostash if rebase
-git config --local rebase.autoStash true
+# Never autostash if rebase
+git config --local rebase.autoStash false
 # Specify an external helper to be called when a username 
 # or password credential is needed (MAC only)
 git config --local credential.helper osxkeychain

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -28,7 +28,7 @@ _core_autocrlf_windows=("core.autocrlf" "true")
 ## Pull
 _pull_rebase=("pull.rebase" "true")
 ## Rebase
-_rebase_autoStash=("rebase.autoStash" "true")
+_rebase_autoStash=("rebase.autoStash" "false")
 ## Credentials, MAC only
 _credential_helper_darwin=("credential.helper" "osxkeychain")
 

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -38,7 +38,7 @@ teardown() {
     [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
     [[ "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]
     [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
-    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash false ==" ]]
     # negative checks are used instead of checking commands size
     [[ ! "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
     [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
@@ -53,7 +53,7 @@ teardown() {
     [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
     [[ "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
     [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
-    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash false ==" ]]
     # negative checks are used instead of checking commands size
     [[ ! "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
     [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]
@@ -68,7 +68,7 @@ teardown() {
     [[ "${lines[@]}" =~ "== git config --local fetch.pruneTags true ==" ]]
     [[ "${lines[@]}" =~ "== git config --local core.autocrlf input ==" ]]
     [[ "${lines[@]}" =~ "== git config --local pull.rebase true ==" ]]
-    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash true ==" ]]
+    [[ "${lines[@]}" =~ "== git config --local rebase.autoStash false ==" ]]
     [[ "${lines[@]}" =~ "== git config --local credential.helper osxkeychain ==" ]]
     # negative checks are used instead of checking commands size
     [[ ! "${lines[@]}" =~ "== git config --local core.autocrlf true ==" ]]


### PR DESCRIPTION
This option is disabled by defalut since it's not safe in the case when
there is no unstashed changes. It fails actual rebase process,
especially when `accept-work` is used.