### PR TITLE
Override default branch name in `deliver-work` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,9 +184,14 @@ echo ...
 usage: git elegant deliver-work
 ```
 
+```bash
+usage: git elegant deliver-work 'remote-branch'
+```
+
 Updates the current branch by rebasing the default upstream branch. Then,
 it pushes HEAD to appropriate upstream branch. The name of remote branch is
-equal to the local one.
+equal to the local one (example 1). If the name of remote branch and the 
+local one is different you can pass the name of remote branch (example 2)
 
 Approximate commands flow is
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,6 +122,13 @@ Updates the current branch using the latest remote `master` and updates remote r
 usage: git deliver-work
 ```
 
+If the name of the remote branch is different from the local one,
+you can pass a parameter with the name of the remote branch.
+
+```bash
+usage: git deliver-work 'YOUR_BRANCH'
+```
+
 A sequence of original `git` commands:
 ```bash
 git fetch

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -9,5 +9,9 @@ default() {
     fi
     boxtee git fetch
     boxtee git rebase ${RMASTER}
-    boxtee git push --set-upstream --force origin ${BRANCH}:${BRANCH}
+   if [[ ! -z "$REMOTE_BRANCH" ]]; then
+        boxtee git push --set-upstream --force origin :${REMOTE_BRANCH}${BRANCH}
+    else
+        boxtee git push --set-upstream --force origin ${BRANCH}:${BRANCH}
+    fi
 }

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -37,5 +37,9 @@ default() {
     fi
     git-verbose fetch
     git-verbose rebase ${RMASTER}
-    git-verbose push --set-upstream --force origin ${BRANCH}:${BRANCH}
+    local REMOTE_BRANCH=${BRANCH}
+    if [ -n "${1}" ]; then
+        REMOTE_BRANCH=${1}
+    fi
+    boxtee git push --set-upstream --force origin ${BRANCH}:${REMOTE_BRANCH}
 }


### PR DESCRIPTION
Add ability to pass remote branch name to delivery_work command
Also readme update
#121 