### PR TITLE
Don't use `obtain-work` in `clear-local`

### DIFF
--- a/libexec/git-elegant-clear-local
+++ b/libexec/git-elegant-clear-local
@@ -31,7 +31,7 @@ MESSAGE
 }
 
 default() {
-    git elegant obtain-work ${MASTER}
+    git-verbose checkout ${MASTER}
     local cmd="git branch -lvv | grep gone | awk {'print \$1'}"
     __loop "git branch -d" $(eval "$cmd") || \
         (

--- a/tests/git-elegant-clear-local.bats
+++ b/tests/git-elegant-clear-local.bats
@@ -3,18 +3,20 @@
 load addons-common
 load addons-read
 load addons-fake
+load addons-git
 
 setup() {
+    init-repo
+    gitrepo git branch --force first
     fake-pass git "branch -lvv" "first [gone]"
-    fake-pass git "elegant obtain-work master"
-    fake-pass git "branch -d first"
 }
 
 teardown() {
     clean-fake
+    clean-git
 }
 
 @test "'clear-local': command is available" {
-  check git-elegant clear-local
-  [ "$status" -eq 0 ]
+    check git-elegant clear-local
+    [[ "${status}" -eq 0 ]]
 }


### PR DESCRIPTION
`obtain-work` is replaced with `git checkout` command to switch a branch
before making a cleanup.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
