### PR TITLE
Print git commands when execute `clear-local`

### DIFF
--- a/libexec/git-elegant-clear-local
+++ b/libexec/git-elegant-clear-local
@@ -33,10 +33,10 @@ MESSAGE
 default() {
     git-verbose checkout ${MASTER}
     local cmd="git branch -lvv | grep gone | awk {'print \$1'}"
-    __loop "git branch -d" $(eval "$cmd") || \
+    __loop "git-verbose branch -d" $(eval "$cmd") || \
         (
             info-text "There are unmerged branches:" && \
             __loop "info-text -" $(eval "$cmd") && \
-            __batch "Do you want to delete all unmerged branches?" "Delete this?" "git branch -D" $(eval "$cmd")
+            __batch "Do you want to delete all unmerged branches?" "Delete this?" "git-verbose branch -D" $(eval "$cmd")
         )
 }


### PR DESCRIPTION
The prosed changes appertain to #167.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
