### PR TITLE
Override default branch name in `deliver-work` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -181,12 +181,13 @@ echo ...
 # `deliver-work`
 
 ```bash
-usage: git elegant deliver-work
+usage: git elegant deliver-work [branch name]
 ```
 
 Updates the current branch by rebasing the default upstream branch. Then,
-it pushes HEAD to appropriate upstream branch. The name of remote branch is
-equal to the local one.
+it pushes HEAD to appropriate upstream branch. By default, the name of remote
+branch is equal to the local one. Also, you can give a custom name of
+the remote branch if needed.
 
 Approximate commands flow is
 ```bash

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -9,15 +9,16 @@ MESSAGE
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant deliver-work
+usage: git elegant deliver-work [branch name]
 MESSAGE
 }
 
 command-description() {
     cat<<MESSAGE
 Updates the current branch by rebasing the default upstream branch. Then,
-it pushes HEAD to appropriate upstream branch. The name of remote branch is
-equal to the local one.
+it pushes HEAD to appropriate upstream branch. By default, the name of remote
+branch is equal to the local one. Also, you can give a custom name of
+the remote branch if needed.
 
 Approximate commands flow is
 \`\`\`bash
@@ -37,5 +38,9 @@ default() {
     fi
     git-verbose fetch
     git-verbose rebase ${RMASTER}
-    git-verbose push --set-upstream --force origin ${BRANCH}:${BRANCH}
+    local REMOTE_BRANCH=${BRANCH}
+    if [ -n "${1}" ]; then
+        REMOTE_BRANCH=${1}
+    fi
+    git-verbose push --set-upstream --force origin ${BRANCH}:${REMOTE_BRANCH}
 }

--- a/tests/git-elegant-deliver-work.bats
+++ b/tests/git-elegant-deliver-work.bats
@@ -18,6 +18,16 @@ teardown() {
     [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature1" ]]
 }
 
+@test "'deliver-work': if branch name passed, a name of remote branch is different to local branch" {
+    fake-pass git branch *feature1
+    fake-pass git "fetch"
+    fake-pass git "rebase origin/master"
+    fake-pass git "push --set-upstream --force origin feature1:feature2"
+    check git-elegant deliver-work feature2
+    [ "$status" -eq 0 ]
+    [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature2" ]]
+}
+
 @test "'deliver-work': exit code is 42 when current local branch is master" {
     fake-pass git branch *master
     fake-pass git "fetch"


### PR DESCRIPTION
Add ability to pass remote branch name to delivery_work command
Add test to delivery_work command with branch_name passed
Also readme update

The proposed changes appertain to #121 .

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
