### PR TITLE
Don't remove `_` and `-`symbols when fake commands

### DIFF
--- a/tests/addons-fake.bash
+++ b/tests/addons-fake.bash
@@ -17,7 +17,7 @@ fake() {
     # sample: fake <command> <exit> <stdout> <stderr>
     local executable=$(basename ${1%% *})
     local fake_directory="${FAKES_DIRECTORY}/${executable}-app"
-    local command_directory="${fake_directory}/$(echo "${1}" | sed 's/[^0-9a-zA-Z]*//g')"
+    local command_directory="${fake_directory}/$(echo "${1}" | sed 's/[^0-9a-zA-Z_-]*//g')"
     local fake="${FAKES_DIRECTORY}/${executable}"
 
     if [[ ! -e "${fake}" ]]; then
@@ -31,7 +31,7 @@ fake() {
 # It's purpose is to use a mock, if available, otherwise,
 # run original executable.
 root_directory=${fake_directory}
-command_directory="\${root_directory}/\$(echo "${executable} \${@}" | sed 's/[^0-9a-zA-Z]*//g')"
+command_directory="\${root_directory}/\$(echo "${executable} \${@}" | sed 's/[^0-9a-zA-Z_-]*//g')"
 if [[ -e "\${command_directory}" ]]; then
     cat "\${command_directory}/stdout"
     cat "\${command_directory}/stderr" >&2

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -12,7 +12,7 @@ setup() {
     fake-pass "git merge --ff-only __eg"
     fake-pass "git push origin master:master"
     fake-pass "git branch --delete --force __eg"
-    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/_eg}" "origin/test-feature"
+    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
     fake-pass "git push origin --delete test-feature"
 }
 


### PR DESCRIPTION
We have to keep `_` and `-` symbols when fake commands as they will
provide better differentiation between commands or their arguments.

The proposed changes appertain to #154.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`
