### PR TITLE
Add `show-release-notes` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,9 @@ There are commands used in various situations such as
     obtain-work          Checkouts a remote branch matching by a name.
     accept-work          Applies a branch on top of upstream branch.
 
+ release new versions
+    show-release-notes   Prints a release log between two references.
+
  and others
     commands             Prints available Elegant Git commands.
 
@@ -259,6 +262,29 @@ Approximate commands flow is
 git add --interactive
 git diff --cached --check
 git commit
+```
+
+# `show-release-notes`
+
+```bash
+usage: git elegant show-release-notes [<layout> | <layout> <from-reference> | <layout> <from-reference> <to-reference>]
+```
+
+Generates a release notes using commits subjects between the given references.
+The commits are ordered from oldest to newest. By default, the `from-reference`
+is the last available tag, and the `to-reference` is a HEAD revision.
+
+There are two options for a `layout`:
+
+1. `simple` prints the messages as a plain text (default one)
+2. `smart` prints the messages in a form of adopted for a git hosting. If the
+hosting is unknown, the default layout is used. Now only GitHub is supported
+(an HTML output).
+
+Approximate commands flow is
+```bash
+==>> git elegant show-release-notes
+git .....
 ```
 
 # `start-work`

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -68,6 +68,10 @@ branch-from-remote-reference() {
     echo ${1} | sed "s|^[a-zA-Z0-9_-]*/||g"
 }
 
+remove-file() {
+    [[ -f ${1} ]] && rm ${1}
+}
+
 --print-command-in-usage() { (
     source "${BINS}/git-elegant-${1}"
     printf "    %-20s %s\n" "${1}" "$(command-purpose)"
@@ -101,6 +105,9 @@ $(--print-command-in-usage deliver-work)
  operate a flow of work management
 $(--print-command-in-usage obtain-work)
 $(--print-command-in-usage accept-work)
+
+ release new versions
+$(--print-command-in-usage show-release-notes)
 
  and others
 $(--print-command-in-usage commands)

--- a/libexec/git-elegant-show-release-notes
+++ b/libexec/git-elegant-show-release-notes
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+command-purpose() {
+    cat <<MESSAGE
+Prints a release log between two references.
+MESSAGE
+}
+
+command-synopsis() {
+    cat <<MESSAGE
+usage: git elegant show-release-notes [<layout> | <layout> <from-reference> | <layout> <from-reference> <to-reference>]
+MESSAGE
+}
+
+command-description() {
+    cat<<MESSAGE
+Generates a release notes using commits subjects between the given references.
+The commits are ordered from oldest to newest. By default, the \`from-reference\`
+is the last available tag, and the \`to-reference\` is a HEAD revision.
+
+There are two options for a \`layout\`:
+
+1. \`simple\` prints the messages as a plain text (default one)
+2. \`smart\` prints the messages in a form of adopted for a git hosting. If the
+hosting is unknown, the default layout is used. Now only GitHub is supported
+(an HTML output).
+
+Approximate commands flow is
+\`\`\`bash
+==>> git elegant show-release-notes
+git .....
+\`\`\`
+MESSAGE
+}
+
+--github-release-notes() {
+    local first="${1}"
+    local second="${2}"
+    local changelog="github-release-notes"
+    echo "<p>Release notes<p>" > ${changelog}
+    local url=$(git remote get-url origin)
+    local repository=""
+    [[ ${url} =~ "github.com/" ]] && repository=${url##*github.com/}
+    [[ ${url} =~ "github.com:" ]] && repository=${url##*github.com:}
+    repository=${repository%%.git}
+
+    for hash in $(git log ${first}...${second} --format=%H --reverse); do
+        local issues=$(git show -s --pretty=%B ${hash} | grep "#")
+        [[ ! -z ${issues} ]] && issues=" [${issues}]"
+        local subject=$(git show -s --pretty=%s ${hash})
+        echo "<li> <a href=\"https://github.com/${repository}/commit/${hash}\">${subject}</a>${issues}</li>" >> ${changelog}
+    done
+    cat ${changelog}
+    remove-file ${changelog}
+}
+
+--simple-release-notes() {
+    local first="${1}"
+    local second="${2}"
+    local changelog="simple-release-notes"
+    echo "Release notes" > ${changelog}
+    for hash in $(git log ${first}...${second} --format=%H --reverse); do
+        echo "- $(git show -s --pretty=%s ${hash})" >> ${changelog}
+    done
+    cat ${changelog}
+    remove-file ${changelog}
+}
+
+default() {
+    local layout="${1}"
+    local first="${2}"
+    local second="${3}"
+    if [[ -z "${layout}" ]]; then
+        layout=simple
+    fi
+    if [[ -z "${first}" ]]; then
+        first=$(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/tags --count 1)
+    fi
+    if [[ -z "${second}" ]]; then
+        second=HEAD
+    fi
+
+    case ${layout} in
+        simple)
+            --simple-release-notes ${first} ${second}
+            ;;
+        smart)
+            if [[ "$(git remote get-url origin)" =~ ((https://)|(git@))github.com ]]; then
+                --github-release-notes ${first} ${second}
+            else
+                --simple-release-notes ${first} ${second}
+            fi
+            ;;
+        *)  error-text "A layout can be 'simple' or 'smart'! '${layout}' layout is not supported."
+            exit 43;;
+
+    esac
+}

--- a/tests/addons-repo.bash
+++ b/tests/addons-repo.bash
@@ -33,6 +33,15 @@ repo-staged-change(){
     perform-verbose git add ${FILE_TO_MODIFY}
 }
 
+repo-commit-file() {
+    # Commits a new file to the repository
+    # usage: repo-commit-file <file name>
+    perform-verbose cd ${GIT_REPO_DIR}
+    touch "${1}"
+    git add "${1}"
+    git commit --message "Add ${1}"
+}
+
 repo() {
     # execute given arguments on real git repo
     # usage: repo <command and arguments>

--- a/tests/git-elegant-commands.bats
+++ b/tests/git-elegant-commands.bats
@@ -20,6 +20,7 @@ teardown() {
         "clear-local"
         "commands"
         "amend-work"
+        "show-release-notes"
     )
     check git-elegant commands
     [ ${#lines[@]} -eq ${#COMMANDS[@]} ]

--- a/tests/git-elegant-show-release-notes.bats
+++ b/tests/git-elegant-show-release-notes.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats -ex
+
+load addons-common
+load addons-fake
+load addons-repo
+
+first=first.txt
+second=second.txt
+third=third.txt
+
+setup() {
+    repo-new
+    repo-commit-file ${first}
+    repo "git tag -a -m ${first} 1"
+    repo-commit-file ${second}
+    repo "git tag -a -m ${second} 2"
+    repo-commit-file ${third}
+    repo "git tag && git log --oneline"
+
+}
+
+teardown() {
+    fake-clean
+    repo-clean
+}
+
+@test "'show-release-notes': the defaults are used when there are no arguments specified" {
+    fake-pass "git remote get-url origin" "https://fake-repo.git"
+    check git-elegant show-release-notes
+    [[ "${status}" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ ${first} ]]
+    [[ ! "${lines[@]}" =~ ${second} ]]
+    [[ "${lines[@]}" =~ ${third} ]]
+    [[ "${#lines[@]}" -eq 2 ]]
+}
+
+@test "'show-release-notes': a 'from-reference' is used when it is specified" {
+    fake-pass "git remote get-url origin" "https://fake-repo.git"
+    check git-elegant show-release-notes simple 1
+    [[ "${status}" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ ${first} ]]
+    [[ "${lines[@]}" =~ ${second} ]]
+    [[ "${lines[@]}" =~ ${third} ]]
+    [[ "${#lines[@]}" -eq 3 ]]
+}
+
+
+@test "'show-release-notes': a 'to-reference' is used when it is specified" {
+    fake-pass "git remote get-url origin" "https://fake-repo.git"
+    check git-elegant show-release-notes simple 1 HEAD
+    [[ "${status}" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ ${first} ]]
+    [[ "${lines[@]}" =~ ${second} ]]
+    [[ "${lines[@]}" =~ ${third} ]]
+}
+
+@test "'show-release-notes': a GitHub layout is used if 'git@git@github.com' is in remote URL" {
+    fake-pass "git remote get-url origin" "git@github.com:bees-hive/elegant-git.git"
+    check git-elegant show-release-notes smart 1 @
+    [[ "${status}" -eq 0 ]]
+    [[ "${lines[@]}" =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
+}
+
+@test "'show-release-notes': a GitHub layout is used if 'https://github.com' is in remote URL" {
+    fake-pass "git remote get-url origin" "https://github.com/bees-hive/elegant-git.git"
+    check git-elegant show-release-notes smart 1 @
+    [[ "${status}" -eq 0 ]]
+    [[ "${lines[@]}" =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
+}
+
+@test "'show-release-notes': raise error 43 if a given layout is unknown" {
+    check git-elegant show-release-notes some
+    [[ "${status}" -eq 43 ]]
+    [[ "${lines[@]}" =~ "'some' layout is not supported." ]]
+}


### PR DESCRIPTION
`show-release-notes` provides a release log which is useful if you need
having a changeset between two references (for instance, release
documentation purposes).

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@alexbeatnik , please review.
