### PR TITLE
Add aliases for all Elegant Git commands

### DIFF
--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -167,5 +167,5 @@ default() {
         _core_autocrlf_darwinlinux _core_autocrlf_windows _pull_rebase \
         _rebase_autoStash _credential_helper_darwin
       __remove-old-aliases
-      __aliases-configuration "pull" "clear-local" $(git elegant commands | grep work)
+      __aliases-configuration $(git elegant commands)
 }

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -76,10 +76,11 @@ teardown() {
 
 @test "'acquire-repository': aliases configuration works as expected" {
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "==>> git config --local alias.start-work elegant start-work" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local alias.save-work elegant save-work" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local alias.deliver-work elegant deliver-work" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local alias.accept-work elegant accept-work" ]]
+    for next in $(git-elegant commands); do
+        echo "Test aliasing of '${next}' command"
+        [[ "${lines[@]}" =~ "==>> git config --local alias.${next} elegant ${next}" ]]
+        echo "Tested successfully!"
+    done
 }
 
 @test "'acquire-repository': local aliases are removed as expected" {


### PR DESCRIPTION
The aliases will be created based on the dynamic loading of all available
commands. This solves a problem with obsolete aliases configuration as
well as simplifies maintenance.

This change should not have any side effects.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
