### PR TITLE
Add instructions for BASH completion installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,9 +15,14 @@ Git's commands in order to get Elegant Git working by default.
 Run `curl https://raw.githubusercontent.com/bees-hive/elegant-git/master/install.bash | $(which bash)`
 and follow the provided instructions to install the tool. `${HOME}/.elegant-git` directory will host
 all required files. That's why if you want to remove installation, you need to remove this directory
-only (`rm -r ${HOME}/.elegant-git`).  
+only (`rm -r ${HOME}/.elegant-git`).
+
+Elegant Git's BASH completion does not work without regular Git BASH completion. If you don't have
+it, please follow <https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion>
+in addition to Elegant Git's configuration.
 
 # Homebrew installation
 On macOS, you can install [Homebrew](https://brew.sh/) if you haven't already, then run
-`brew install bees-hive/hive/elegant-git`. To find out more please visit
-<https://github.com/bees-hive/homebrew-hive>.
+`brew install git` (we must install Git with Homebrew in order to have a working BASH completion)
+and `brew install bees-hive/hive/elegant-git` (please visit
+<https://github.com/bees-hive/homebrew-hive> if you need details).


### PR DESCRIPTION
Git BASH completion always has to be installed along with Elegant Git
completion in order to have the last completion working.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.

@alexbeatnik please test instructions and let me know if they work on your environments.