### PR TITLE
Make BASH completion working for `git-elegant` file

### DIFF
--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -7,7 +7,7 @@ _git_elegant() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "${prev}" in
-        elegant)
+        elegant|git-elegant)
             opts=($(git elegant commands))
             COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cur}) )
             return 0 ;;
@@ -24,3 +24,5 @@ _git_elegant() {
             return 0 ;;
     esac
 }
+
+complete -F _git_elegant git-elegant


### PR DESCRIPTION
A user may invoke `git elegant` as well as `git-elegant`. And we have to
provide BASH completion in both cases. That's why the completion
function is now registered for `git-elegant` name. And it works for `git
elegant` also.

The proposed changes appertain to #205.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
