### PR TITLE
Use existing upstream branch if available when `deliver-work`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -194,13 +194,16 @@ echo ...
 # `deliver-work`
 
 ```bash
-usage: git elegant deliver-work [branch name]
+usage: git elegant deliver-work [branch-name]
 ```
 
 Updates the current branch by rebasing the default upstream branch. Then,
-it pushes HEAD to appropriate upstream branch. By default, the name of remote
-branch is equal to the local one. Also, you can give a custom name of
-the remote branch if needed.
+it pushes HEAD to the appropriate upstream branch.
+
+By default, the name of remote branch is equal to the local one. If a local
+branch has an upstream branch configured, it will be used as a remote branch.
+If you provide a custom name of the remote branch, it will be used as a remote
+branch.
 
 If there are uncommitted changes, they will be stashed prior to the command
 execution and un-stashed after its successful completion. This is useful if you

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -9,16 +9,19 @@ MESSAGE
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant deliver-work [branch name]
+usage: git elegant deliver-work [branch-name]
 MESSAGE
 }
 
 command-description() {
     cat<<MESSAGE
 Updates the current branch by rebasing the default upstream branch. Then,
-it pushes HEAD to appropriate upstream branch. By default, the name of remote
-branch is equal to the local one. Also, you can give a custom name of
-the remote branch if needed.
+it pushes HEAD to the appropriate upstream branch.
+
+By default, the name of remote branch is equal to the local one. If a local
+branch has an upstream branch configured, it will be used as a remote branch.
+If you provide a custom name of the remote branch, it will be used as a remote
+branch.
 
 If there are uncommitted changes, they will be stashed prior to the command
 execution and un-stashed after its successful completion. This is useful if you
@@ -37,11 +40,19 @@ MESSAGE
 --deliver-work-logic() {
     git-verbose fetch
     git-verbose rebase ${RMASTER}
-    local remote_branch=${1}
+    local upstream=$(git branch --list --format "%(upstream:lstrip=2)" ${1})
+    local remote_branch=${upstream/*\//}
+    local remote=${upstream/\/*/}
     if [[ -n "${2}" ]]; then
         remote_branch=${2}
     fi
-    git-verbose push --set-upstream --force origin ${1}:${remote_branch}
+    if [[ -z "${remote_branch}" ]]; then
+        remote_branch=${1}
+    fi
+    if [[ -z "${remote}" ]]; then
+        remote=${REMOTE_NAME}
+    fi
+    git-verbose push --set-upstream --force ${remote} ${1}:${remote_branch}
 }
 
 default() {

--- a/tests/git-elegant-deliver-work.bats
+++ b/tests/git-elegant-deliver-work.bats
@@ -7,6 +7,8 @@ load addons-repo
 
 setup() {
     repo-new
+    fake-pass "git fetch"
+    fake-pass "git rebase origin/master"
 }
 
 teardown() {
@@ -15,40 +17,43 @@ teardown() {
 }
 
 @test "'deliver-work': by default, a name of remote branch is equal to local branch" {
-    fake-pass "git rev-parse --abbrev-ref HEAD" feature1
-    fake-pass "git fetch"
-    fake-pass "git rebase origin/master"
+    repo "git checkout -b feature1"
     fake-pass "git push --set-upstream --force origin feature1:feature1"
     check git-elegant deliver-work
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
     [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature1" ]]
 }
 
 @test "'deliver-work': if branch name passed, a name of remote branch is different to local branch" {
-    fake-pass "git rev-parse --abbrev-ref HEAD" feature1
-    fake-pass "git fetch"
-    fake-pass "git rebase origin/master"
+    repo "git checkout -b feature1"
     fake-pass "git push --set-upstream --force origin feature1:feature2"
     check git-elegant deliver-work feature2
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
     [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature2" ]]
 }
 
 @test "'deliver-work': exit code is 42 when current local branch is master" {
-    fake-pass "git rev-parse --abbrev-ref HEAD" master
-    fake-pass "git fetch"
-    fake-pass "git rebase origin/master"
-    fake-pass "git push --set-upstream --force origin master:master"
     check git-elegant deliver-work
-    [ "$status" -eq 42 ]
-    [ "${lines[1]}" = "== No pushes to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]
+    [[ "${status}" -eq 42 ]]
+    [[ "${lines[1]}" = "== No pushes to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
 }
 
 @test "'deliver-work': use stash pipe if there are uncommitted changes" {
-    fake-pass "git pull"
+    repo "git checkout -b feature1"
     repo-non-staged-change "A new line..."
-    check git-elegant start-work test-feature
-    [[ "$status" -eq 0 ]]
+    fake-pass "git push --set-upstream --force origin feature1:feature1"
+    check git-elegant deliver-work
+    [[ "${status}" -eq 0 ]]
     [[ "${lines[@]}" =~ "git stash push" ]]
     [[ "${lines[@]}" =~ "git stash pop" ]]
+}
+
+@test "'deliver-work': use existing upstream branch if it is available" {
+    repo "git checkout -b some/remote"
+    repo "git checkout -b feature1"
+    repo "git branch --set-upstream-to some/remote"
+    fake-pass "git push --set-upstream --force some feature1:remote"
+    check git-elegant deliver-work
+    [[ "${status}" -eq 0 ]]
+    [[ "${lines[@]}" =~ "git push --set-upstream --force some feature1:remote" ]]
 }


### PR DESCRIPTION
This makes the `deliver-work` more friendly as it evaluates a current
state of a local branch. If the branch does not have an upstream, it
will be set. Otherwise, the command will reuse existing upstream when
making a force push of the current state.

The proposed changes appertain to #207.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
