### PR TITLE
Open URLs from push output if they are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ it. Each command file has to provide the following BASH functions:
 ### Coding rules
 We enforce having a consistent implementation by following the next strict rules:
 - add `#!/usr/bin/env bash` at the beginning of each script
-- use `git-verbose` instead of `git` if you need to print a `git`'s command to CLI
+- use whether `git-verbose` or `git-verbose-op` instead of `git` command for well-formatted outputs
 - a private function (a usage in the scope of current script) should be prefixed with `--`
 
 If you need to write a message to the system output, please use public functions in

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -209,6 +209,9 @@ If there are uncommitted changes, they will be stashed prior to the command
 execution and un-stashed after its successful completion. This is useful if you
 need to deliver only sub-set of the changes.
 
+If the push output contains an URL (like a link to create a pull request), it
+will be open (in case if `open` command is available) in a default browser.
+
 Approximate commands flow is
 ```bash
 ==>> git elegant deliver-work

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -13,8 +13,21 @@ __site="https://elegant-git.bees-hive.org"
 
 
 git-verbose() {
+    # Prints a command to be executed and executes it using `git` executable.
+    # usage: git-verbose [arg]...
     command-text "git $@"
     git "$@"
+}
+
+git-verbose-op() {
+    # Prints a command to be executed, executes it using `git` executable,
+    # prints the output, and processes the output by a given function.
+    # usage: git-verbose-op <function> [arg]...
+    local processor=${1}; shift
+    command-text "git $@"
+    local output=$(git "$@" 2>&1)
+    echo "${output}"
+    ${processor} "${output}"
 }
 
 MASTER="master"

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -27,6 +27,9 @@ If there are uncommitted changes, they will be stashed prior to the command
 execution and un-stashed after its successful completion. This is useful if you
 need to deliver only sub-set of the changes.
 
+If the push output contains an URL (like a link to create a pull request), it
+will be open (in case if \`open\` command is available) in a default browser.
+
 Approximate commands flow is
 \`\`\`bash
 ==>> git elegant deliver-work
@@ -35,6 +38,13 @@ git rebase origin/master
 git push --set-upstream --force origin task-123:task-123
 \`\`\`
 MESSAGE
+}
+
+--open-urls-if-possible() {
+    type open >/dev/null 2>&1 || return 0
+    for line in ${1}; do
+        [[ ${line} =~ ^http(.+) ]] && open ${line}
+    done
 }
 
 --deliver-work-logic() {
@@ -52,7 +62,7 @@ MESSAGE
     if [[ -z "${remote}" ]]; then
         remote=${REMOTE_NAME}
     fi
-    git-verbose push --set-upstream --force ${remote} ${1}:${remote_branch}
+    git-verbose-op --open-urls-if-possible push --set-upstream --force ${remote} ${1}:${remote_branch}
 }
 
 default() {

--- a/tests/git-elegant-deliver-work.bats
+++ b/tests/git-elegant-deliver-work.bats
@@ -57,3 +57,11 @@ teardown() {
     [[ "${status}" -eq 0 ]]
     [[ "${lines[@]}" =~ "git push --set-upstream --force some feature1:remote" ]]
 }
+
+@test "'deliver-work': open URls if they are present in the push output" {
+    repo "git checkout -b feature1"
+    fake-pass "git push --set-upstream --force origin feature1:feature1" "remote: https://pull/new/some"
+    fake "open https://pull/new/some" 23
+    check git-elegant deliver-work
+    [[ "${status}" -eq 23 ]]
+}


### PR DESCRIPTION
Some git hostings provide useful URLs after pushing changes like links
for pull requests. And this change automates their opening after
delivering work. If there are several URLs, all of them will be open.

The proposed changes appertain to #165.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
