### PR TITLE
Don't add `show-release-notes` call to the release notes

### DIFF
--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -21,13 +21,11 @@ git-verbose() {
 
 git-verbose-op() {
     # Prints a command to be executed, executes it using `git` executable,
-    # prints the output, and processes the output by a given function.
+    # and processes the output by a given function instead of printing it.
     # usage: git-verbose-op <function> [arg]...
     local processor=${1}; shift
     command-text "git $@"
-    local output=$(git "$@" 2>&1)
-    echo "${output}"
-    ${processor} "${output}"
+    ${processor} "$(git "$@" 2>&1)"
 }
 
 MASTER="master"

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -41,7 +41,7 @@ MESSAGE
 }
 
 --open-urls-if-possible() {
-    type open >/dev/null 2>&1 || return 0
+    type open >/dev/null 2>&1 || { echo "${1}"; return 0; }
     for line in ${1}; do
         [[ ${line} =~ ^http(.+) ]] && open ${line}
     done

--- a/libexec/git-elegant-release-work
+++ b/libexec/git-elegant-release-work
@@ -36,6 +36,19 @@ git elegant show-release-notes smart 1.1.12 1.2.0
 MESSAGE
 }
 
+--copy-notes-if-possible(){
+    local default_tool="cat"
+    local copy_tool=${default_tool}
+    # mac
+    type pbcopy >/dev/null 2>&1 && copy_tool="pbcopy"
+    # linux
+    type xclip >/dev/null 2>&1 && copy_tool="xclip -selection clipboard"
+    echo "${1}" | ${copy_tool}
+    if [[ ! "${default_tool}" == "${copy_tool}" ]]; then
+        info-text "The release notes are copied to clipboard."
+    fi
+}
+
 --release-work() {
     git-verbose checkout ${MASTER}
     git-verbose pull --tags
@@ -54,21 +67,7 @@ MESSAGE
     git-verbose tag --annotate --file ${message} --edit ${new_tag}
     remove-file ${message}
     git-verbose push --tags
-
-
-    local default_tool="cat"
-    local copy_tool=${default_tool}
-    # mac
-    which pbcopy >/dev/null && copy_tool="pbcopy"
-    # linux
-    which xclip >/dev/null && copy_tool="xclip -selection clipboard"
-    (
-        git-verbose elegant show-release-notes smart ${last_tag} ${new_tag}
-    ) | ${copy_tool}
-    if [[ ! "${default_tool}" == "${copy_tool}" ]]; then
-        info-text "The release notes are copied to clipboard."
-    fi
-
+    git-verbose-op --copy-notes-if-possible elegant show-release-notes smart ${last_tag} ${new_tag}
 }
 
 default() {

--- a/tests/git-elegant-release-work.bats
+++ b/tests/git-elegant-release-work.bats
@@ -22,8 +22,6 @@ setup() {
     fake-pass "git pull --tags"
     fake-pass "git push --tags"
     fake-pass "git tag --annotate --file tag-message --edit ${new_tag}"
-    fake-fail "which pbcopy"
-    fake-fail "which xclip"
     fake-pass "git remote get-url origin" "https://fake-repo.git"
     read-answer ${new_tag}
 }


### PR DESCRIPTION
The `release-work` command uses the `git-verbose-op` function for
handling release notes. This change allows excluding of `show-release-notes`
invocation from a release notes being redirected to a clipboard.

Also, `which` is replaced with `type` in order to rely on builtin
functions.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
