### PR TITLE
Skip workflows if needed

### DIFF
--- a/.workflows/bats-pipeline.bash
+++ b/.workflows/bats-pipeline.bash
@@ -2,7 +2,9 @@
 set -e
 # Runs bats tests
 # usage: ./script [command name]
-
+if [[ -f version ]]; then
+    rm -v version
+fi
 if [[ -n "${1}" ]]; then
     bats --tap $(find tests -type f -name "*${1}*")
 else

--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -3,41 +3,63 @@
 _git_elegant() {
     COMPREPLY=()
     local cursor="${COMP_WORDS[COMP_CWORD]}"
-
+    local geops="--help --version --no-workflows"
+    local gecops="--help --no-workflows"
+    local offset=0
+    if [[ ${COMP_WORDS[*]} =~ (--no-workflows)|(-nw) ]]; then
+        geops=""
+        gecops=""
+        if [[ ${COMP_WORDS[COMP_CWORD-1]} =~ (--no-workflows)|(-nw) ]]; then
+            offset=1
+        fi
+    fi
     # the first word prior to the ${cursor}
-    case ""${COMP_WORDS[COMP_CWORD-1]}"" in
-        elegant|git-elegant)
-            local opts=($(git elegant commands))
-            COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-            return 0 ;;
-        accept-work|obtain-work)
-            COMPREPLY=(
-                $(compgen -W "$(git branch --remotes --list)" -- ${cursor})
-            )
-            return 0 ;;
-        show-release-notes)
-            COMPREPLY=( $(compgen -W "simple smart" ${cursor}) )
-            return 0 ;;
-        *)  ;;
-    esac
+    if [[ ${#COMP_WORDS[*]} > $(( 1 + ${offset} )) ]]; then
+        case "${COMP_WORDS[COMP_CWORD-$(( 1 + ${offset} ))]}" in
+            elegant|git-elegant)
+                local opts=(
+                    ${geops}
+                    $(git elegant commands)
+                )
+                COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
+                return 0 ;;
+            accept-work|obtain-work)
+                local opts=(
+                    ${gecops}
+                    $(git branch --remotes --list)
+                )
+                COMPREPLY=(
+                    $(compgen -W "${opts[*]}" -- ${cursor})
+                )
+                return 0 ;;
+            show-release-notes)
+                COMPREPLY=( $(compgen -W "simple smart ${gecops[*]}" -- ${cursor}) )
+                return 0 ;;
+            *)  ;;
+        esac
+    fi
 
     # the second word prior to the ${cursor}
-    case "${COMP_WORDS[COMP_CWORD-2]}" in
-        show-release-notes)
-            local opts=($(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/**))
-            COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-            return 0 ;;
-        *)  ;;
-    esac
+    if [[ ${#COMP_WORDS[*]} > $(( 2 + ${offset} )) ]]; then
+        case "${COMP_WORDS[COMP_CWORD-$(( 2 + ${offset} ))]}" in
+            show-release-notes)
+                local opts=($(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/**))
+                COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
+                return 0 ;;
+            *)  ;;
+        esac
+    fi
 
     # the third word prior to the ${cursor}
-    case "${COMP_WORDS[COMP_CWORD-3]}" in
-        show-release-notes)
-            local opts=($(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/**))
-            COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-            return 0 ;;
-        *)  ;;
-    esac
+    if [[ ${#COMP_WORDS[*]} > $(( 3 + ${offset} )) ]]; then
+        case "${COMP_WORDS[COMP_CWORD-$(( 3 + ${offset} ))]}" in
+            show-release-notes)
+                local opts=($(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/**))
+                COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
+                return 0 ;;
+            *)  ;;
+        esac
+    fi
 }
 
 complete -F _git_elegant git-elegant

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,11 +3,14 @@
 
 An assistant who carefully automates routine work with Git.
 
-usage: git elegant [-h | --help | help]
-   or: git elegant [-v | --version | version]
-   or: git elegant <command> [args]
+usage: git elegant [-h | --help | help | --version | version]
    or: git elegant <command> [-h | --help | help]
+   or: git elegant <command> [--no-workflows] [args]
+   or: git elegant [--no-workflows] <command> [args]
 
+    -h, --help, help    displays help
+    --version, version  displays program version
+    --no-workflows      disables available workflows
 
 There are commands used in various situations such as
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,9 @@ A sample workflow execution:
 ❗Please take into that if an action returns a non-zero exit code, the execution of the workflow
 will be interrupted.
 
+If you want to skip workflows for the current command execution, just use `--no-workflows` option
+like `git elegant --no-workflows save-work`.
+
 # Known limitations
 Support only one default remote - `origin`.
 

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -94,11 +94,14 @@ remove-file() {
 
 An assistant who carefully automates routine work with Git.
 
-usage: git elegant [-h | --help | help]
-   or: git elegant [-v | --version | version]
-   or: git elegant <command> [args]
+usage: git elegant [-h | --help | help | --version | version]
    or: git elegant <command> [-h | --help | help]
+   or: git elegant <command> [--no-workflows] [args]
+   or: git elegant [--no-workflows] <command> [args]
 
+    -h, --help, help    displays help
+    --version, version  displays program version
+    --no-workflows      disables available workflows
 
 There are commands used in various situations such as
 
@@ -145,12 +148,21 @@ MESSAGE
     --run-file ".workflows/${command}-${type}"
 }
 
+--load-command(){
+    local commandfile="${BINS}/git-elegant-${1}"
+    if [[ -f ${commandfile} ]]; then
+        source ${commandfile}
+    else
+        echo "Unknown command: git elegant ${1}"
+        --usage
+        exit 46
+    fi
+}
+
 --run-command() {
     # usage: <command name> [arg]...
     local COMMAND=${1}; shift
-    . "${BINS}/git-elegant-${COMMAND}" 2>/dev/null || {
-        echo "Unknown command: git elegant $COMMAND" && --usage && exit 46
-    }
+    --load-command ${COMMAND}
     case "${1}" in
         -h|--help|help)
             echo ""
@@ -158,6 +170,10 @@ MESSAGE
             echo ""
             command-description
             echo ""
+            ;;
+        --no-workflows)
+            shift
+            default "$@"
             ;;
         *)
             --run-workflow ahead ${COMMAND}
@@ -171,9 +187,19 @@ main() {
     local COMMAND="none"
     [[ -n "$1" ]] && COMMAND="$1" && shift
     case "${COMMAND}" in
-        none|-h|--help|help)    --usage                       ;;
-        -v|--version|version)   cat "${BINS}/../version"      ;;
-        *)                      --run-command ${COMMAND} "$@" ;;
+        none|-h|--help|help)
+            --usage
+            ;;
+        --version|version)
+            cat "${BINS}/../version"
+            ;;
+        --no-workflows)
+            COMMAND=${1}
+            shift
+            --run-command ${COMMAND} --no-workflows "$@"
+            ;;
+        *)  --run-command ${COMMAND} "$@"
+            ;;
     esac
 }
 

--- a/tests/git-elegant.bats
+++ b/tests/git-elegant.bats
@@ -56,8 +56,35 @@ load addons-common
     [[ "${lines[-1]}" == "after no" ]]
 }
 
+@test "'git elegant': workflows are ignored if --no-workflows is set before a command" {
+    perform-verbose mkdir -p .workflows
+    echo "echo ahead no" | tee -i .workflows/commands-ahead
+    echo "echo after no" | tee -i .workflows/commands-after
+    perform-verbose chmod +x .workflows/*
+    perform-verbose ls -lah .workflows/*
+    check git-elegant --no-workflows commands
+    [[ "$status" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ ".workflows/commands-ahead" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/commands-after" ]]
+}
+
+@test "'git elegant': workflows are ignored if --no-workflows is set after a command" {
+    perform-verbose mkdir -p .workflows
+    echo "echo ahead no" | tee -i .workflows/commands-ahead
+    echo "echo after no" | tee -i .workflows/commands-after
+    perform-verbose chmod +x .workflows/*
+    perform-verbose ls -lah .workflows/*
+    check git-elegant commands --no-workflows
+    [[ "$status" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ ".workflows/commands-ahead" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/commands-after" ]]
+}
+
 teardown(){
      if [[ -d ".workflows" ]]; then
-        perform-verbose rm -rv .git/.workflows .workflows
+        perform-verbose rm -rv .workflows
+     fi
+     if [[ -d ".git/.workflows" ]]; then
+        perform-verbose rm -rv .git/.workflows
      fi
 }

--- a/workflows
+++ b/workflows
@@ -35,9 +35,6 @@ repository() {
 }
 
 ci() {
-    if [[ -f version ]]; then
-        rm -v version
-    fi
     docker run --rm -v $PWD:/eg ${WORKER_IMAGE} .workflows/ci-pipeline.bash testing
 }
 


### PR DESCRIPTION
Sometimes, a user may want to ignore defined workflows and just execute
a pure command. And `--no-workflows` option is designed to implement
this behavior. This option can be put prior or after the command. This
gives more flexibility in usage. However, `git-elegan --no-workflows
<command>` is preffered as it encourages to split Elegant Git options
and command arguments. Bash completion is updated appropriately.

Also, two improvements:
1. The `version` file will be removed prior to actual test execution.
This exposes the mentioned behavior for any place where
`.workflows/bats-pipeline.bash` is used.
2. Remove `-v` option (was equal to `--version`) as, in Git, `-v` stands
for `--verbose`.

The proposed changes appertain to #192.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
