### PR TITLE
Add `--help` and `--no-workflows` for all commands

### DIFF
--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -35,7 +35,9 @@ _git_elegant() {
             show-release-notes)
                 COMPREPLY=( $(compgen -W "simple smart ${gecops[*]}" -- ${cursor}) )
                 return 0 ;;
-            *)  ;;
+            *)
+                COMPREPLY=( $(compgen -W "${gecops[*]}" -- ${cursor}) )
+                return 0 ;;
         esac
     fi
 


### PR DESCRIPTION
By default, complete each Elegant Git command with `--help` and
`--no-workflows` options if a custom completion is not specified.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
