### PR TITLE
Use `<h3>` HTML tag to format header linei of release notes

### DIFF
--- a/libexec/git-elegant-show-release-notes
+++ b/libexec/git-elegant-show-release-notes
@@ -40,7 +40,7 @@ MESSAGE
     local first="${1}"
     local second="${2}"
     local changelog="github-release-notes"
-    echo "<p>Release notes<p>" > ${changelog}
+    echo "<h3>Release notes</h3>" > ${changelog}
     local url=$(git remote get-url origin)
     local repository=""
     [[ ${url} =~ "github.com/" ]] && repository=${url##*github.com/}


### PR DESCRIPTION
A header of release message should be highlighted (h3) during the
preparation of Github release notes. This allows a user to have
a highlighted section within the current description of a release.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
