### PR TITLE
Prevent "git-elegant: command not found" error on Brew

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -60,7 +60,7 @@ main() {
         copy "${path}" ${INSTALL_PATH}
     fi
     echo "Elegant Git is installed to '${INSTALL_PATH}/bin/git-elegant'."
-    git-elegant acquire-git
+    ${INSTALL_PATH}/bin/git-elegant acquire-git
     command -v git-elegant 1>/dev/null 2>&1 || next-steps ${INSTALL_PATH}
 }
 


### PR DESCRIPTION
During the Brew's installation, the installed binary file won't be
available in the PATH. That's why it should be invoked via a full path.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
