### PR TITLE
Use `vi` as the default editor during testing and debugging

### DIFF
--- a/.workflows/ci-pipeline.bash
+++ b/.workflows/ci-pipeline.bash
@@ -17,7 +17,7 @@ pipeline() {
         echo "Installation...."
         git config --global user.name "Elegant Git"
         git config --global user.email elegant.git@email.com
-        git config --global core.editor some-editor
+        git config --global core.editor vi
         git config --global elegant.acquired true
         ./install.bash /usr/local src
         echo "'Unknown command' testing..."

--- a/tests/addons-repo.bash
+++ b/tests/addons-repo.bash
@@ -11,7 +11,7 @@ repo-new() {
         perform-verbose git init
         perform-verbose git config --local user.email "\"elegant-git@example.com\""
         perform-verbose git config --local user.name "\"Elegant Git\""
-        perform-verbose git config --local core.editor "\"edi\""
+        perform-verbose git config --local core.editor "\"vi\""
         perform-verbose touch ${FILE_TO_MODIFY}
         perform-verbose git add .
         perform-verbose git commit -m "\"Add ${FILE_TO_MODIFY}\""

--- a/tests/git-elegant-acquire-git.bats
+++ b/tests/git-elegant-acquire-git.bats
@@ -28,8 +28,8 @@ teardown() {
     [[ "${lines[@]}" =~ "==>> git config --global user.name Elegant Git" ]]
     [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ "${lines[@]}" =~ "==>> git config --global user.email elegant-git@example.com" ]]
-    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {edi}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.editor edi" ]]
+    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ "${lines[@]}" =~ "==>> git config --global core.editor vi" ]]
 }
 
 @test "'acquire-git': standards are configured as expected on Windows" {

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -25,8 +25,8 @@ teardown() {
     [[ "${lines[@]}" =~ "==>> git config --local user.name Elegant Git" ]]
     [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ "${lines[@]}" =~ "==>> git config --local user.email elegant-git@example.com" ]]
-    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {edi}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local core.editor edi" ]]
+    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ "${lines[@]}" =~ "==>> git config --local core.editor vi" ]]
 }
 
 @test "'acquire-repository': standards are configured as expected on Windows" {
@@ -101,8 +101,8 @@ teardown() {
     [[ "${lines[@]}" =~ "==>> git config --local user.name Elegant Git" ]]
     [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ "${lines[@]}" =~ "==>> git config --local user.email elegant-git@example.com" ]]
-    [[ ! "${lines[@]}" =~ "Please specify a command to start the editor. {edi}: " ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.editor edi" ]]
+    [[ ! "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ! "${lines[@]}" =~ "==>> git config --local core.editor vi" ]]
     [[ ! "${lines[@]}" =~ "==>> git config --local core.commentChar |" ]]
     [[ "${lines[@]}" =~ "1 Elegant Git aliases were removed." ]]
     [[ ! "${lines[@]}" =~ "==>> git config --local alias.acquire-repository elegant acquire-repository" ]]

--- a/workflows
+++ b/workflows
@@ -33,7 +33,7 @@ repository() {
         cd /eg
         git config --global user.name \"Elegant Git\"
         git config --global user.email elegant.git@email.com
-        git config --global core.editor some-editor
+        git config --global core.editor vi
         git config --global elegant.acquired true
         ./install.bash /usr/local src
     "


### PR DESCRIPTION
All testing and debugging activities are performed within a Docker
container. And sometimes, the real editor is required to make some
experiments. As the dummy editor was used, some commands were failed as
it does not work. For instance, when an interactive rebase is executed.

As the solution, the `vi` editor now is used the default editor for git.
It is available in our alpine-based Docker image, that's why the CI will
work without changes.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
