### PR TITLE
Apply only created stashes automatically

### DIFF
--- a/libexec/plugins/pipe
+++ b/libexec/plugins/pipe
@@ -13,6 +13,9 @@ has-changes() {
 stash-pipe() {
     # Makes automatic stash and unstash if possible
     # usage:  stash-pipe <command> [args]...
+    # The pipe behavior is tested based on `start-work` command. That's why you
+    # have to add new tests in `git-elegant-start-work.bats` if you want to
+    # check some specific cases.
 
     git update-index -q --really-refresh
     if has-changes; then
@@ -24,9 +27,12 @@ stash-pipe() {
 
     "${@}"
 
-    if [[ -n "${message}" ]]; then
+    if [[ -n ${message} ]]; then
         git update-index -q --really-refresh
-        git-verbose stash pop $(git stash list --grep="${message}" --format="%gd")
+        local stash=$(git stash list --grep="${message}" --format="%gd")
+        if [[ -n ${stash} ]]; then
+            git-verbose stash pop ${stash}
+        fi
     fi
 }
 

--- a/tests/git-elegant-start-work.bats
+++ b/tests/git-elegant-start-work.bats
@@ -29,7 +29,7 @@ teardown() {
     [[ "${lines[0]}" =~ "Please give a name for the new branch." ]]
 }
 
-@test "'start-work': use stash pipe if there are uncommitted changes" {
+@test "'start-work': tracked changes move to a new branch when they are available" {
     repo-non-staged-change "A new line..."
     check git-elegant start-work test-feature
     [[ "$status" -eq 0 ]]
@@ -37,15 +37,17 @@ teardown() {
     [[ "${lines[@]}" =~ "stash pop" ]]
 }
 
-@test "'start-work': ignore stash pipe if there are uncommitted changes" {
-    fake-pass "git stash save elegant-git" "No local changes to save"
+@test "'start-work': stash commands don't run when there are no tracked changes" {
     check git-elegant start-work test-feature
-    [ "$status" -eq 0 ]
+    [[ "$status" -eq 0 ]]
+    [[ ! "${lines[@]}" =~ "stash push" ]]
+    [[ ! "${lines[@]}" =~ "stash pop" ]]
 }
 
-@test "'start-work': exit code is 100 when stash pipe wasn't applied" {
-    repo-non-staged-change "A new line..."
-    fake-fail "git stash pop stash@{0}"
+@test "'start-work': stash is not applied when it is not found for a given message" {
+    fake-fail "git diff-index --quiet HEAD"
     check git-elegant start-work test-feature
-    [[ "$status" -eq 100 ]]
+    [[ "$status" -eq 0 ]]
+    [[ "${lines[@]}" =~ "stash push" ]]
+    [[ ! "${lines[@]}" =~ "stash pop" ]]
 }


### PR DESCRIPTION
There are cases when Git says about modification, although they are
absent in a working tree. And Elegant Git, as it sees the changes, will
try to stash them. But the stash won't be created (Git just says: "No
local changes to save"), and, as the exit code is 0, the next command
will be executed. At this point, Elegant Git will assume, that created
stash (which is false) must be uncovered after commands execution. And
it will apply the last available stash instead of doing nothing. That's
why a check is added that sees if there is a real created stash
that must be uncovered.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
