### PR TITLE
Don't ask issue number in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-The proposed changes appertain to #_.
-
 The contribution:
 - [ ] updates all affected documentation
 - [ ] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules


### PR DESCRIPTION
By the contribution guide, a contributor should specify the issue number
in a commit message if possible. That's why there is on sense to ask
about it again in a pull request. Additionally, if there is only one
commit, its message will be inserted prior to template message while
creating a new pull request. So, this simple change should speed up
the creation of the pull requests.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
