### PR TITLE
Rename `commands` command to `show-commands`

### DIFF
--- a/.workflows/docs-generation.bash
+++ b/.workflows/docs-generation.bash
@@ -18,7 +18,7 @@ report-command() {
 
 report-commands() {
     echo "Write all commands to '${1}'"
-    for command in $(git-elegant commands); do
+    for command in $(git-elegant show-commands); do
         report-command ${command} ${1}
     done
 }

--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -19,7 +19,7 @@ _git_elegant() {
             elegant|git-elegant)
                 local opts=(
                     ${geops}
-                    $(git elegant commands)
+                    $(git elegant show-commands)
                 )
                 COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
                 return 0 ;;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,7 +36,7 @@ There are commands used in various situations such as
     release-work         Releases available work as a new annotated tag.
 
  and others
-    commands             Prints available Elegant Git commands.
+    show-commands        Prints available Elegant Git commands.
     acquire-git          Configures a Git installation.
 
 
@@ -155,22 +155,6 @@ Approximate commands flow is
 git clone git@github.com:bees-hive/elegant-git.git
 cd elegant-git
 git elegant acquire-repository
-```
-
-# `commands`
-
-```bash
-usage: git elegant commands
-```
-
-Displays all available commands. This is useful for completion functions as well
-as for other cases when you need iteration over the available commands.
-
-Approximate commands flow is
-```bash
-==>> git elegant commands
-echo <command>
-echo ...
 ```
 
 # `deliver-work`
@@ -301,6 +285,24 @@ Approximate commands flow is
 git add --interactive
 git diff --cached --check
 git commit
+```
+
+# `show-commands`
+
+```bash
+usage: git elegant show-commands
+```
+
+Displays all available Elegant Git commands. This is useful for completion
+functions as well as for other cases when you need iteration over the available
+commands.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-commands
+start-work
+show-commands
+....
 ```
 
 # `show-release-notes`

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -127,7 +127,7 @@ $(--print-command-in-usage show-release-notes)
 $(--print-command-in-usage release-work)
 
  and others
-$(--print-command-in-usage commands)
+$(--print-command-in-usage show-commands)
 $(--print-command-in-usage acquire-git)
 
 

--- a/libexec/git-elegant-acquire-git
+++ b/libexec/git-elegant-acquire-git
@@ -76,5 +76,5 @@ MESSAGE
       credential_helper_darwin \
       acquired
     aliases-removing --global
-    aliases-configuration --global $(git elegant commands)
+    aliases-configuration --global $(git elegant show-commands)
 }

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -40,6 +40,6 @@ default() {
           rebase_autoStash \
           credential_helper_darwin
         aliases-removing --local
-        aliases-configuration --local $(git elegant commands)
+        aliases-configuration --local $(git elegant show-commands)
     fi
 }

--- a/libexec/git-elegant-show-commands
+++ b/libexec/git-elegant-show-commands
@@ -9,20 +9,22 @@ MESSAGE
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant commands
+usage: git elegant show-commands
 MESSAGE
 }
 
 command-description() {
     cat<<MESSAGE
-Displays all available commands. This is useful for completion functions as well
-as for other cases when you need iteration over the available commands.
+Displays all available Elegant Git commands. This is useful for completion
+functions as well as for other cases when you need iteration over the available
+commands.
 
 Approximate commands flow is
 \`\`\`bash
-==>> git elegant commands
-echo <command>
-echo ...
+==>> git elegant show-commands
+start-work
+show-commands
+....
 \`\`\`
 MESSAGE
 }

--- a/tests/git-elegant-acquire-git.bats
+++ b/tests/git-elegant-acquire-git.bats
@@ -82,7 +82,7 @@ teardown() {
 
 @test "'acquire-git': new aliases are configured as expected" {
     check git-elegant acquire-git
-    for next in $(git-elegant commands); do
+    for next in $(git-elegant show-commands); do
         echo "Test aliasing of '${next}' command"
         [[ "${lines[@]}" =~ "==>> git config --global alias.${next} elegant ${next}" ]]
         echo "Tested successfully!"

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -76,7 +76,7 @@ teardown() {
 
 @test "'acquire-repository': new aliases are configured as expected" {
     check git-elegant acquire-repository
-    for next in $(git-elegant commands); do
+    for next in $(git-elegant show-commands); do
         echo "Test aliasing of '${next}' command"
         [[ "${lines[@]}" =~ "==>> git config --local alias.${next} elegant ${next}" ]]
         echo "Tested successfully!"

--- a/tests/git-elegant-show-commands.bats
+++ b/tests/git-elegant-show-commands.bats
@@ -7,7 +7,7 @@ teardown() {
     fake-clean
 }
 
-@test "'commands': print all available commands" {
+@test "'show-commands': print all available Elegant Git commands" {
     COMMANDS=(
         "acquire-repository"
         "acquire-git"
@@ -19,20 +19,20 @@ teardown() {
         "accept-work"
         "obtain-work"
         "clear-local"
-        "commands"
+        "show-commands"
         "amend-work"
         "show-release-notes"
         "release-work"
         "polish-work"
     )
-    check git-elegant commands
+    check git-elegant show-commands
     [ ${#lines[@]} -eq ${#COMMANDS[@]} ]
     for command in ${COMMANDS[@]}; do
         [[ "${lines[@]}" =~ "${command}" ]]
     done
 }
 
-@test "'commands': default exit code is 0" {
-    check git-elegant commands
+@test "'show-commands': default exit code is 0" {
+    check git-elegant show-commands
     [ "$status" -eq 0 ]
 }

--- a/tests/git-elegant.bats
+++ b/tests/git-elegant.bats
@@ -15,7 +15,7 @@ load addons-common
 }
 
 @test "'git elegant': a help is provided for each available command" {
-    for COMMAND in $(git-elegant commands) ; do
+    for COMMAND in $(git-elegant show-commands) ; do
         echo "Check help for '${COMMAND}'"
         check git-elegant ${COMMAND} -h
         [[ "$status" -eq 0 ]]
@@ -25,7 +25,7 @@ load addons-common
 
 @test "'git elegant': each command is included in main help message" {
     check git-elegant --help
-    for COMMAND in $(git-elegant commands) ; do
+    for COMMAND in $(git-elegant show-commands) ; do
         echo "Check presence of '${COMMAND}'"
         [[ "${lines[@]}" =~ "${COMMAND}" ]]
     done
@@ -38,46 +38,46 @@ load addons-common
 
 @test "'git elegant': workflows are loaded correctly" {
     perform-verbose mkdir -p .workflows .git/.workflows
-    echo "echo ahead git" | tee -i .git/.workflows/commands-ahead
-    echo "echo ahead no" | tee -i .workflows/commands-ahead
-    echo "echo after git" | tee -i .git/.workflows/commands-after
-    echo "echo after no" | tee -i .workflows/commands-after
+    echo "echo ahead git" | tee -i .git/.workflows/show-commands-ahead
+    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
+    echo "echo after git" | tee -i .git/.workflows/show-commands-after
+    echo "echo after no" | tee -i .workflows/show-commands-after
     perform-verbose chmod +x .git/.workflows/* .workflows/*
     perform-verbose ls -lah .git/.workflows/* .workflows/*
-    check git-elegant commands
+    check git-elegant show-commands
     [[ "$status" -eq 0 ]]
-    [[ "${lines[0]}" =~ ".git/.workflows/commands-ahead" ]]
+    [[ "${lines[0]}" =~ ".git/.workflows/show-commands-ahead" ]]
     [[ "${lines[1]}" == "ahead git" ]]
-    [[ "${lines[2]}" =~ ".workflows/commands-ahead" ]]
+    [[ "${lines[2]}" =~ ".workflows/show-commands-ahead" ]]
     [[ "${lines[3]}" == "ahead no" ]]
-    [[ "${lines[-4]}" =~ ".git/.workflows/commands-after" ]]
+    [[ "${lines[-4]}" =~ ".git/.workflows/show-commands-after" ]]
     [[ "${lines[-3]}" == "after git" ]]
-    [[ "${lines[-2]}" =~ ".workflows/commands-after" ]]
+    [[ "${lines[-2]}" =~ ".workflows/show-commands-after" ]]
     [[ "${lines[-1]}" == "after no" ]]
 }
 
 @test "'git elegant': workflows are ignored if --no-workflows is set before a command" {
     perform-verbose mkdir -p .workflows
-    echo "echo ahead no" | tee -i .workflows/commands-ahead
-    echo "echo after no" | tee -i .workflows/commands-after
+    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
+    echo "echo after no" | tee -i .workflows/show-commands-after
     perform-verbose chmod +x .workflows/*
     perform-verbose ls -lah .workflows/*
-    check git-elegant --no-workflows commands
+    check git-elegant --no-workflows show-commands
     [[ "$status" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ".workflows/commands-ahead" ]]
-    [[ ! "${lines[@]}" =~ ".workflows/commands-after" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/show-commands-ahead" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/show-commands-after" ]]
 }
 
 @test "'git elegant': workflows are ignored if --no-workflows is set after a command" {
     perform-verbose mkdir -p .workflows
-    echo "echo ahead no" | tee -i .workflows/commands-ahead
-    echo "echo after no" | tee -i .workflows/commands-after
+    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
+    echo "echo after no" | tee -i .workflows/show-commands-after
     perform-verbose chmod +x .workflows/*
     perform-verbose ls -lah .workflows/*
-    check git-elegant commands --no-workflows
+    check git-elegant show-commands --no-workflows
     [[ "$status" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ".workflows/commands-ahead" ]]
-    [[ ! "${lines[@]}" =~ ".workflows/commands-after" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/show-commands-ahead" ]]
+    [[ ! "${lines[@]}" =~ ".workflows/show-commands-after" ]]
 }
 
 teardown(){


### PR DESCRIPTION
The rename makes the command unambiguous as it explains what to do with
the commands - show them.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
