### PR TITLE
Remove remote branches only for `origin` after accepting work

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,7 @@ There are commands used in various situations such as
 
  operate a flow of work management
     obtain-work          Checkouts a remote branch matching by a name.
-    accept-work          Applies a branch on top of upstream branch.
+    accept-work          Applies a branch on top of `master` branch.
 
  release new versions
     show-release-notes   Prints a release log between two references.
@@ -51,10 +51,12 @@ usage: git elegant accept-work <remote branch>
 ```
 
 Checkouts given branch using `git elegant obtain-work` into a temporary one.
-Then, it makes a rebase of the latest version of default upstream branch with
-current changes. The final index merges using fast-forward strategy into the
-default local branch and pushes into the default upstream branch. After a
-successful push, the given and temporary branches are removed.
+Then, it makes a rebase of the latest version of default upstream branch
+(`master`) with current changes. The final prepared index merges using
+fast-forward strategy into the default local branch and pushes into the
+default upstream branch (`origin/master`). After a successful push, the
+temporary branch is removed as well as given branch if it locates in `origin`
+remote.
 
 Prior to the execution, a current state is saved (a branch with modifications).
 After the successful accepting a work, the state will be restored. In the case

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -3,7 +3,7 @@ set -e
 
 command-purpose() {
     cat <<MESSAGE
-Applies a branch on top of upstream branch.
+Applies a branch on top of \`master\` branch.
 MESSAGE
 }
 
@@ -16,10 +16,12 @@ MESSAGE
 command-description() {
     cat<<MESSAGE
 Checkouts given branch using \`git elegant obtain-work\` into a temporary one.
-Then, it makes a rebase of the latest version of default upstream branch with
-current changes. The final index merges using fast-forward strategy into the
-default local branch and pushes into the default upstream branch. After a
-successful push, the given and temporary branches are removed.
+Then, it makes a rebase of the latest version of default upstream branch
+(\`master\`) with current changes. The final prepared index merges using
+fast-forward strategy into the default local branch and pushes into the
+default upstream branch (\`origin/master\`). After a successful push, the
+temporary branch is removed as well as given branch if it locates in \`origin\`
+remote.
 
 Prior to the execution, a current state is saved (a branch with modifications).
 After the successful accepting a work, the state will be restored. In the case
@@ -57,7 +59,9 @@ MESSAGE
     git-verbose merge --ff-only ${WORK_BRANCH}
     git-verbose push ${REMOTE_NAME} ${MASTER}:${MASTER}
     git-verbose branch --delete --force ${WORK_BRANCH}
-    git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-reference ${ACTUAL_REMOTE})
+    if [[ ${ACTUAL_REMOTE} =~ ^origin/ ]];  then
+        git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-reference ${ACTUAL_REMOTE})
+    fi
 }
 
 default() {

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -6,14 +6,11 @@ load addons-repo
 
 setup() {
     repo-new
+    repo "git checkout -b __eg; git checkout -"
     fake-pass "git elegant obtain-work test-feature __eg"
     fake-pass "git rebase origin/master"
     fake-pass "git fetch --all"
-    fake-pass "git merge --ff-only __eg"
     fake-pass "git push origin master:master"
-    fake-pass "git branch --delete --force __eg"
-    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
-    fake-pass "git push origin --delete test-feature"
 }
 
 teardown() {
@@ -22,21 +19,32 @@ teardown() {
 }
 
 @test "'accept-work': a work is accepted successfully for given remote branch" {
+    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
+    fake-fail "git push origin --delete test-feature"
     check git-elegant accept-work test-feature
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 100 ]]
 }
 
 @test "'accept-work': exit code is 45 when remote branch name isn't set" {
     check git-elegant accept-work
-    [[ "${status}" -eq 45 ]]
+    [[ ${status} -eq 45 ]]
 }
 
 @test "'accept-work': save WIP prior accepting and restore after it" {
     repo "git checkout -b other"
     repo-non-staged-change "A new line..."
+    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
+    fake-pass "git push origin --delete test-feature"
     check git-elegant accept-work test-feature
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "git stash push" ]]
-    [[ "${lines[@]}" =~ "git stash pop" ]]
-    [[ "${lines[@]}" =~ "git checkout other" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git stash push" ]]
+    [[ ${lines[@]} =~ "git stash pop" ]]
+    [[ ${lines[@]} =~ "git checkout other" ]]
+}
+
+@test "'accept-work': a remote branch is not removed when it is pulled from fork" {
+    fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin-a/test-feature"
+    fake-fail "git push origin --delete test-feature"
+    check git-elegant accept-work test-feature
+    [[ ${status} -eq 0 ]]
 }


### PR DESCRIPTION
A user may accept work from forked remotes. In this case, it's possible
that a remote fork provides only pull permissions. And, in order to
prevent errors, the removal is enabled only for `origin` - is a user
accepts work, it has a write permissions to `origin`.

#171

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
