### PR TITLE
Support workflows from repository subtrees

### DIFF
--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -112,8 +112,9 @@ MESSAGE
 --run-workflow(){
     local type=${1}
     local command=${2}
-    --run-file ".git/.workflows/${command}-${type}"
-    --run-file ".workflows/${command}-${type}"
+    local prefix=$(git rev-parse --show-cdup)
+    --run-file "${prefix}.git/.workflows/${command}-${type}"
+    --run-file "${prefix}.workflows/${command}-${type}"
 }
 
 --load-command(){

--- a/tests/git-elegant-clone-repository.bats
+++ b/tests/git-elegant-clone-repository.bats
@@ -9,6 +9,7 @@ setup() {
     fake-pass "git clone-repository"
     fake-pass "git clone https://github.com/extsoft/elegant-git.git"
     fake-pass "git elegant acquire-repository"
+    fake-pass "git rev-parse --show-cdup"
 }
 
 teardown() {

--- a/tests/git-elegant-show-commands.bats
+++ b/tests/git-elegant-show-commands.bats
@@ -3,6 +3,10 @@
 load addons-common
 load addons-fake
 
+setup() {
+    fake-pass "git rev-parse --show-cdup"
+}
+
 teardown() {
     fake-clean
 }

--- a/tests/git-elegant.bats
+++ b/tests/git-elegant.bats
@@ -1,6 +1,16 @@
 #!/usr/bin/env bats
 
 load addons-common
+load addons-repo
+
+setup() {
+    repo-new
+}
+
+teardown(){
+    repo-clean
+}
+
 
 @test "'git elegant': a help is displayed if a command is not provided" {
     check git-elegant
@@ -36,55 +46,68 @@ load addons-common
     [[ "${lines[@]}" =~ "/eg/tests/../libexec/../version" ]]
 }
 
-@test "'git elegant': workflows are loaded correctly" {
-    perform-verbose mkdir -p .workflows .git/.workflows
-    echo "echo ahead git" | tee -i .git/.workflows/show-commands-ahead
-    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
-    echo "echo after git" | tee -i .git/.workflows/show-commands-after
-    echo "echo after no" | tee -i .workflows/show-commands-after
-    perform-verbose chmod +x .git/.workflows/* .workflows/*
-    perform-verbose ls -lah .git/.workflows/* .workflows/*
+@test "'git elegant': workflows are loaded correctly when a command is executed from root directory" {
+    repo "mkdir -p .workflows .git/.workflows"
+    repo "echo echo ahead git > .git/.workflows/show-commands-ahead"
+    repo "echo echo ahead no > .workflows/show-commands-ahead"
+    repo "echo echo after git > .git/.workflows/show-commands-after"
+    repo "echo echo after no > .workflows/show-commands-after"
+    repo "chmod +x .git/.workflows/* .workflows/*"
+    repo "ls -lah .git/.workflows/* .workflows/*"
     check git-elegant show-commands
-    [[ "$status" -eq 0 ]]
-    [[ "${lines[0]}" =~ ".git/.workflows/show-commands-ahead" ]]
-    [[ "${lines[1]}" == "ahead git" ]]
-    [[ "${lines[2]}" =~ ".workflows/show-commands-ahead" ]]
-    [[ "${lines[3]}" == "ahead no" ]]
-    [[ "${lines[-4]}" =~ ".git/.workflows/show-commands-after" ]]
-    [[ "${lines[-3]}" == "after git" ]]
-    [[ "${lines[-2]}" =~ ".workflows/show-commands-after" ]]
-    [[ "${lines[-1]}" == "after no" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[0]} =~ ".git/.workflows/show-commands-ahead" ]]
+    [[ ${lines[1]} == "ahead git" ]]
+    [[ ${lines[2]} =~ ".workflows/show-commands-ahead" ]]
+    [[ ${lines[3]} == "ahead no" ]]
+    [[ ${lines[-4]} =~ ".git/.workflows/show-commands-after" ]]
+    [[ ${lines[-3]} == "after git" ]]
+    [[ ${lines[-2]} =~ ".workflows/show-commands-after" ]]
+    [[ ${lines[-1]} == "after no" ]]
+}
+
+@test "'git elegant': workflows are loaded correctly when a command is executed from non-root directory" {
+    repo mkdir -p .workflows .git/.workflows
+    repo "echo echo ahead git > .git/.workflows/show-commands-ahead"
+    repo "echo echo ahead no > .workflows/show-commands-ahead"
+    repo "echo echo after git > .git/.workflows/show-commands-after"
+    repo "echo echo after no > .workflows/show-commands-after"
+    repo "chmod +x .git/.workflows/* .workflows/*"
+    repo "ls -lah .git/.workflows/* .workflows/*"
+    repo "mkdir -p some/path"
+    repo "cd some/path"
+    check git-elegant show-commands
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[0]} =~ ".git/.workflows/show-commands-ahead" ]]
+    [[ ${lines[1]} == "ahead git" ]]
+    [[ ${lines[2]} =~ ".workflows/show-commands-ahead" ]]
+    [[ ${lines[3]} == "ahead no" ]]
+    [[ ${lines[-4]} =~ ".git/.workflows/show-commands-after" ]]
+    [[ ${lines[-3]} == "after git" ]]
+    [[ ${lines[-2]} =~ ".workflows/show-commands-after" ]]
+    [[ ${lines[-1]} == "after no" ]]
 }
 
 @test "'git elegant': workflows are ignored if --no-workflows is set before a command" {
-    perform-verbose mkdir -p .workflows
-    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
-    echo "echo after no" | tee -i .workflows/show-commands-after
-    perform-verbose chmod +x .workflows/*
-    perform-verbose ls -lah .workflows/*
+    repo "mkdir -p .workflows"
+    repo "echo echo ahead no > .workflows/show-commands-ahead"
+    repo "echo echo after no > .workflows/show-commands-after"
+    repo "chmod +x .workflows/*"
+    repo "ls -lah .workflows/*"
     check git-elegant --no-workflows show-commands
-    [[ "$status" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ".workflows/show-commands-ahead" ]]
-    [[ ! "${lines[@]}" =~ ".workflows/show-commands-after" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[@]} =~ ".workflows/show-commands-ahead" ]]
+    [[ ! ${lines[@]} =~ ".workflows/show-commands-after" ]]
 }
 
 @test "'git elegant': workflows are ignored if --no-workflows is set after a command" {
-    perform-verbose mkdir -p .workflows
-    echo "echo ahead no" | tee -i .workflows/show-commands-ahead
-    echo "echo after no" | tee -i .workflows/show-commands-after
-    perform-verbose chmod +x .workflows/*
-    perform-verbose ls -lah .workflows/*
+    repo "mkdir -p .workflows"
+    repo "echo echo ahead no > .workflows/show-commands-ahead"
+    repo "echo echo after no > .workflows/show-commands-after"
+    repo "chmod +x .workflows/*"
+    repo "ls -lah .workflows/*"
     check git-elegant show-commands --no-workflows
-    [[ "$status" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ".workflows/show-commands-ahead" ]]
-    [[ ! "${lines[@]}" =~ ".workflows/show-commands-after" ]]
-}
-
-teardown(){
-     if [[ -d ".workflows" ]]; then
-        perform-verbose rm -rv .workflows
-     fi
-     if [[ -d ".git/.workflows" ]]; then
-        perform-verbose rm -rv .git/.workflows
-     fi
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[@]} =~ ".workflows/show-commands-ahead" ]]
+    [[ ! ${lines[@]} =~ ".workflows/show-commands-after" ]]
 }


### PR DESCRIPTION
During development, the non-root repository directory can be used as
well as a root also. But, regardless of the position in a repository
directories tree, the workflows have toi be executed in the same way.
And it is achieved by updating a workflow file path with the path of
the top-level directory relative to the current directory.

Also, git-elegant.bats uses the real repository for testing since it's
required for workflows testing.

The tests for `clone-repository` and `show-commands` are still support
execution without the real Git repository.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
