### PR TITLE
Display current state of WIP with `show-work` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,6 +24,7 @@ There are commands used in various situations such as
     start-work           Creates a new branch.
     save-work            Commits current modifications.
     amend-work           Amends some changes to the most recent commit.
+    show-work            Shows a state of current work in progress.
     polish-work          Reapplies branch commits interactively.
     deliver-work         Publishes current branch to a remote repository.
 
@@ -337,6 +338,24 @@ Approximate commands flow is
 Release notes
 - Add `show-release-notes` command
 - Add `release-work` command
+```
+
+# `show-work`
+
+```bash
+usage: git elegant show-work
+```
+
+Shows a state of current work by displaying branch information, new commits
+comparing to `master` branch, uncommitted modifications, and available
+stashes.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-work
+git log --oneline master..@
+git status --short
+git stash list
 ```
 
 # `start-work`

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -81,6 +81,7 @@ $(--print-command-in-usage prune-repository)
 $(--print-command-in-usage start-work)
 $(--print-command-in-usage save-work)
 $(--print-command-in-usage amend-work)
+$(--print-command-in-usage show-work)
 $(--print-command-in-usage polish-work)
 $(--print-command-in-usage deliver-work)
 

--- a/libexec/git-elegant-show-work
+++ b/libexec/git-elegant-show-work
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+
+command-purpose() {
+    cat <<MESSAGE
+Shows a state of current work in progress.
+MESSAGE
+}
+
+command-synopsis() {
+    cat <<MESSAGE
+usage: git elegant show-work
+MESSAGE
+}
+
+command-description() {
+    cat<<MESSAGE
+Shows a state of current work by displaying branch information, new commits
+comparing to \`master\` branch, uncommitted modifications, and available
+stashes.
+
+Approximate commands flow is
+\`\`\`bash
+==>> git elegant show-work
+git log --oneline ${MASTER}..@
+git status --short
+git stash list
+\`\`\`
+MESSAGE
+}
+
+default(){
+    local branch=$(git rev-parse --abbrev-ref @)
+    info-text ">>> Work branch:"
+    info-text "local:  ${branch}"
+    local upstream=$(git rev-parse --abbrev-ref ${branch}@{upstream} 2>/dev/null || echo)
+    if [[ -n ${upstream} ]]; then
+        info-text "remote: ${upstream}"
+    fi
+    info-text ""
+    if [[ -n $(git rev-list ${MASTER}..${branch}) ]]; then
+        info-text ">>> New commits (comparing to 'master' branch):"
+        git log --oneline ${MASTER}..${branch}
+        info-text ""
+    fi
+    if [[ -n $(git status --short) ]]; then
+        info-text ">>> Unsaved modifications:"
+        git status --short
+        info-text ""
+    fi
+    if [[ -n $(git stash list) ]]; then
+        info-text ">>> Available stashes:"
+        git stash list
+        info-text ""
+    fi
+}

--- a/tests/git-elegant-show-commands.bats
+++ b/tests/git-elegant-show-commands.bats
@@ -19,6 +19,7 @@ teardown() {
         "init-repository"
         "start-work"
         "save-work"
+        "show-work"
         "deliver-work"
         "accept-work"
         "obtain-work"


### PR DESCRIPTION
Introduced command aims to provide complete information about the
current state of work in progress. This is useful when you need to
see an overall overview of what happens just by running a single
command.

#231

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
