### PR TITLE
Make Elegant Git working with unavailable remote

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -253,6 +253,8 @@ git branch --delete --force 2349
 git branch --delete --force task-1
 ```
 
+The command works even if the remotes are unavailable.
+
 # `release-work`
 
 ```bash
@@ -381,3 +383,5 @@ git checkout -b task-123
 git stash apply stash^{/elegant-git}
 git stash drop stash@{0}
 ```
+
+The command works even if a remote is unavailable.

--- a/libexec/git-elegant-prune-repository
+++ b/libexec/git-elegant-prune-repository
@@ -35,12 +35,14 @@ git branch --delete --force task-24
 git branch --delete --force 2349
 git branch --delete --force task-1
 \`\`\`
+
+The command works even if the remotes are unavailable.
 MESSAGE
 }
 
 default() {
     git-verbose checkout ${MASTER}
-    git-verbose fetch --all
+    git-verbose fetch --all || info-text "As the remotes can't be fetched, the current local version is used."
     for branch in $(git for-each-ref --format "%(refname:short)" refs/heads/**); do
         if [[ ${branch} == ${MASTER} ]]; then continue; fi
         if [[ -n $(git config --get branch.${branch}.merge) ]]; then

--- a/libexec/git-elegant-start-work
+++ b/libexec/git-elegant-start-work
@@ -32,12 +32,14 @@ git checkout -b task-123
 git stash apply stash^{/elegant-git}
 git stash drop stash@{0}
 \`\`\`
+
+The command works even if a remote is unavailable.
 MESSAGE
 }
 
 --start-work-logic(){
     git-verbose checkout ${MASTER}
-    git-verbose pull
+    git-verbose pull || info-text "As the branch can't be pulled, the current local version is used."
     git-verbose checkout -b "$1"
 }
 

--- a/tests/git-elegant-prune-repository.bats
+++ b/tests/git-elegant-prune-repository.bats
@@ -22,6 +22,17 @@ teardown() {
     [[ ${lines[@]} =~ "git branch --delete --force equal-to-master" ]]
 }
 
+@test "'prune-repository': works when the remote repository is unavailable" {
+    repo "git checkout -b equal-to-master"
+    repo "git checkout master"
+    fake-fail "git fetch --all" "Manual fetch fail"
+    check git-elegant prune-repository
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "Manual fetch fail" ]]
+    [[ ${lines[@]} =~ "As the remotes can't be fetched, the current local version is used." ]]
+    [[ ${lines[@]} =~ "git branch --delete --force equal-to-master" ]]
+}
+
 @test "'prune-repository': a branch is alive when it doesn't have an upstream and has a new commit" {
     repo "git checkout -b commit"
     repo-commit-file "commit"

--- a/tests/git-elegant-start-work.bats
+++ b/tests/git-elegant-start-work.bats
@@ -19,6 +19,13 @@ teardown() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "'start-work': works when the remote repository is unavailable" {
+    fake-fail "git pull"
+    check git-elegant start-work test-feature
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "As the branch can't be pulled, the current local version is used." ]]
+}
+
 @test "'start-work': exit code is 45 when branch name isn't set" {
     check git-elegant start-work
     [[ "$status" -eq 45 ]]


### PR DESCRIPTION
A user can do some work in a repository even if there is no access to a
remote. For instance, there is no internet available. In this case,
Elegant Git should be still operable. That's why `prune-repository` and
`start-work` ignore the availability of the remote. All other commands
either can't achieve their purpose without alive remote or don't use it
at all.

#116

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
