### PR TITLE
Add initial commit after initialization of the repository

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -172,14 +172,16 @@ git push --set-upstream --force origin task-123:task-123
 usage: git elegant init-repository
 ```
 
-Creates an empty Git repository (or reinitialize an existing one) and runs its
-configuration.
+Creates an empty Git repository (or reinitialize an existing one), runs its
+configuration, and creates an initial empty commit.
 
 Approximate commands flow is
 ```bash
 ==>> git elegant init-repository
 git init
 git elegant acquire-repository
+git commit --allow-empty --file a-message-of-initial-commit
+git show
 ```
 
 # `obtain-work`

--- a/libexec/git-elegant-init-repository
+++ b/libexec/git-elegant-init-repository
@@ -15,14 +15,16 @@ MESSAGE
 
 command-description() {
     cat<<MESSAGE
-Creates an empty Git repository (or reinitialize an existing one) and runs its
-configuration.
+Creates an empty Git repository (or reinitialize an existing one), runs its
+configuration, and creates an initial empty commit.
 
 Approximate commands flow is
 \`\`\`bash
 ==>> git elegant init-repository
 git init
 git elegant acquire-repository
+git commit --allow-empty --file a-message-of-initial-commit
+git show
 \`\`\`
 MESSAGE
 }
@@ -30,4 +32,22 @@ MESSAGE
 default() {
     git-verbose init
     git elegant acquire-repository
+    local message="a-message-of-initial-commit"
+    cat <<MESSAGE > ${message}
+Add initial empty commit
+
+This commit is the first commit in this working tree. It does not have
+any changes. However, it simplifies further work at least in the
+following cases:
+- it's possible to create a branch now
+- it's possible to manage the second commit if it requires some
+polishing after creation
+
+This commit is created automatically by Elegant Git after the
+initialization of a new repository.
+
+MESSAGE
+    git-verbose commit --allow-empty --file ${message}
+    remove-file ${message}
+    git-verbose show
 }

--- a/tests/addons-repo.bash
+++ b/tests/addons-repo.bash
@@ -12,6 +12,7 @@ repo-new() {
         perform-verbose git config --local user.email "\"elegant-git@example.com\""
         perform-verbose git config --local user.name "\"Elegant Git\""
         perform-verbose git config --local core.editor "\"vi\""
+        perform-verbose git config --local core.pager cat
         perform-verbose touch ${FILE_TO_MODIFY}
         perform-verbose git add .
         perform-verbose git commit -m "\"Add ${FILE_TO_MODIFY}\""

--- a/tests/git-elegant-init-repository.bats
+++ b/tests/git-elegant-init-repository.bats
@@ -1,19 +1,33 @@
 #!/usr/bin/env bats
 
 load addons-common
-load addons-read
 load addons-fake
+current=$(pwd)
+repository=${current}/new-repository
 
 setup() {
-    fake-pass "git init"
     fake-pass "git elegant acquire-repository"
+    perform-verbose "mkdir -p ${repository}"
+    perform-verbose "cd ${repository}"
+    perform-verbose "git config --global user.email you@example.com"
+    perform-verbose "git config --global user.name YourName"
+    perform-verbose "git config --global core.pager cat"
 }
 
 teardown() {
+    perform-verbose "cd ${current}"
+    perform-verbose "rm -rf ${repository}"
+    perform-verbose "git config --global --unset user.email"
+    perform-verbose "git config --global --unset user.name"
+    perform-verbose "git config --global --unset core.pager"
     fake-clean
 }
 
-@test "'init-repository': command is available" {
-  check git-elegant init-repository
-  [ "$status" -eq 0 ]
+@test "'init-repository': creates a new repository with initial commit" {
+    check git-elegant init-repository
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git init" ]]
+    [[ ${lines[@]} =~ "git commit --allow-empty" ]]
+    [[ ${lines[@]} =~ "git show" ]]
+    [[ ${lines[@]} =~ "Add initial empty commit" ]]
 }


### PR DESCRIPTION
After the initialization of a new repository, a user can't use all Git
capabilities until the first commit is created. And, since it can't be
changed, it is better to create the empty commit. `init-repository` will
care about the initial commit and prepare fully-operable repository.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
