### PR TITLE
Use the latest changes of the `master` branch during pruning repository

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -250,6 +250,7 @@ Approximate commands flow is
 ==>> git elegant prune-repository
 git checkout master
 git fetch --all
+git rebase
 git branch --delete --force task-24
 git branch --delete --force 2349
 git branch --delete --force task-1

--- a/libexec/git-elegant-prune-repository
+++ b/libexec/git-elegant-prune-repository
@@ -31,6 +31,7 @@ Approximate commands flow is
 ==>> git elegant prune-repository
 git checkout master
 git fetch --all
+git rebase
 git branch --delete --force task-24
 git branch --delete --force 2349
 git branch --delete --force task-1
@@ -40,13 +41,20 @@ The command works even if the remotes are unavailable.
 MESSAGE
 }
 
+--is-there-upstream-for() {
+    git rev-parse --abbrev-ref ${1}@{upstream} >/dev/null  2>&1
+}
+
 default() {
     git-verbose checkout ${MASTER}
-    git-verbose fetch --all || info-text "As the remotes can't be fetched, the current local version is used."
+    if --is-there-upstream-for ${MASTER}; then
+        git-verbose fetch --all || info-text "As the remotes can't be fetched, the current local version is used."
+        git-verbose rebase
+    fi
     for branch in $(git for-each-ref --format "%(refname:short)" refs/heads/**); do
         if [[ ${branch} == ${MASTER} ]]; then continue; fi
         if [[ -n $(git config --get branch.${branch}.merge) ]]; then
-            if git rev-parse --abbrev-ref ${branch}@{upstream} >/dev/null  2>&1; then
+            if --is-there-upstream-for ${branch}; then
                 # the branch has existing upstream; keep it
                 continue
             fi

--- a/tests/git-elegant-prune-repository.bats
+++ b/tests/git-elegant-prune-repository.bats
@@ -22,10 +22,22 @@ teardown() {
     [[ ${lines[@]} =~ "git branch --delete --force equal-to-master" ]]
 }
 
+@test "'prune-repository': updates current master branch when there is a remote upstream" {
+    repo "git checkout -b equal-to-master"
+    fake-pass "git rev-parse --abbrev-ref master@{upstream}"
+    fake-pass "git rebase"
+    check git-elegant prune-repository
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git fetch --all" ]]
+    [[ ${lines[@]} =~ "git rebase" ]]
+    [[ ${lines[@]} =~ "git branch --delete --force equal-to-master" ]]
+}
+
 @test "'prune-repository': works when the remote repository is unavailable" {
     repo "git checkout -b equal-to-master"
-    repo "git checkout master"
+    fake-pass "git rev-parse --abbrev-ref master@{upstream}"
     fake-fail "git fetch --all" "Manual fetch fail"
+    fake-pass "git rebase"
     check git-elegant prune-repository
     [[ ${status} -eq 0 ]]
     [[ ${lines[@]} =~ "Manual fetch fail" ]]


### PR DESCRIPTION
There are 2 states of the repository:

1. There is a remote configured. This means that the `master` branchi
has an upstream (usually `origin/master`). And after `git fetch --all`,
the `git rebase` has to be executed in order to rebase (merge) fetched
changes to сurrent local branch. Having the latest version is critical
as the `master` branch is used to seeking for useless local branches.

2. There is no remote configured. This means that the `master` branch
is up to date and seeking for useless local branches should be
performed.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
