### PR TITLE
Prevent "not a git repository" error during initiating a repository

### DIFF
--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -113,7 +113,9 @@ MESSAGE
 --run-workflow(){
     local type=${1}
     local command=${2}
-    local prefix=$(git rev-parse --show-cdup)
+    if [[ ! "init-repository clone-repository" =~ ${command} ]]; then
+        local prefix=$(git rev-parse --show-cdup)
+    fi
     --run-file "${prefix}.git/.workflows/${command}-${type}"
     --run-file "${prefix}.workflows/${command}-${type}"
 }


### PR DESCRIPTION
Prior to the execution of any command, Elegant Git seeks the workflow
files. And in order to solve them from any position in a working tree,
it uses Git command for resolving a path to the root of the repository.
In the case, if `init-repository` or `clone-repository` is executed,
Git will raise an error: "not a git repository (or any of the parent
directories): .git." This happens as there is no `.git` directory at the
moment of the command execution.

Now, for both commands (`init-repository` and `clone-repository`), Git
command for the path evaluation won't be executed. This does not affect
the logic of the workflow execution but prevents the error.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
