### PR TITLE
Configure signature for a repository

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -98,8 +98,8 @@ https://elegant-git.bees-hive.org/en/latest/configuration/
 usage: git elegant acquire-repository
 ```
 
-Applies the "basics", "standards", and "aliases" configurations to the current
-Git repository using `git config --local`.
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using `git config --local`.
 
 To find out what will be configured, please visit
 https://elegant-git.bees-hive.org/en/latest/configuration/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,3 +52,17 @@ significantly improve user experience.
 
 The configuration is a call of `git config "alias.<command>" "elegant <command>"` (`i`) for each Elegant
 Git command.
+
+# Signature
+This configuration aims to say Git how to sign commits, tags, and other objects you create. It starts after
+all other configurations. In the beginning, all available signing keys will be shown. Then, you need to choose
+the key that will be used to make signatures. If the key is provided, the configuration triggers, otherwise,
+it does not apply. The signing configuration consists of
+
+1. setting `user.signingkey` (`l`) to a provided value
+2. setting `gpg.program` (`l`) to a full path of `gpg` program
+3. setting `commit.gpgsign` (`l`) to `true`
+4. setting `tag.forceSignAnnotated` (`l`) to `true`
+5. setting `tag.gpgSign` (`l`) to `true`
+
+For now, only `gpg` is supported. If you need other tools, please [create a new feature request](https://github.com/bees-hive/elegant-git/issues/new/choose).

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -15,8 +15,8 @@ MESSAGE
 
 command-description() {
     cat<<MESSAGE
-Applies the "basics", "standards", and "aliases" configurations to the current
-Git repository using \`git config --local\`.
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using \`git config --local\`.
 
 To find out what will be configured, please visit
 ${__site}/en/latest/configuration/
@@ -41,5 +41,30 @@ default() {
           credential_helper_darwin
         aliases-removing --local
         aliases-configuration --local $(git elegant show-commands)
+    fi
+    type -p gpg >/dev/null 2>&1 || return 0
+    info-box "Configuring signature..."
+    local listkeys="gpg --list-secret-keys --keyid-format long $(git config --local user.email)"
+    command-text ${listkeys}
+    ${listkeys}
+    info-text "From the list of GPG keys above, copy the GPG key ID you'd like to use."
+    info-text "It will be"
+    info-text "    3AA5C34371567BD2"
+    info-text "for the output like this"
+    info-text "    sec   4096R/3AA5C34371567BD2 2016-03-10 [expires: 2017-03-10]"
+    info-text "    A330C91F8EC4BC7AECFA63E03AA5C34371567BD2"
+    info-text "    uid                          Hubot"
+    info-text ""
+    info-text "If you don't want to configure signature, just hit Enter button."
+    question-text "Please pass a key that has to sign objects of the current repository: "
+    read key
+    if [[ -n ${key} ]] ; then
+        git-verbose config --local user.signingkey ${key}
+        git-verbose config --local gpg.program $(type -p gpg)
+        git-verbose config --local commit.gpgsign true
+        git-verbose config --local tag.forceSignAnnotated true
+        git-verbose config --local tag.gpgSign true
+    else
+        info-text "The signature is not configured as the empty key is provided."
     fi
 }

--- a/tests/addons-read.bash
+++ b/tests/addons-read.bash
@@ -36,7 +36,7 @@ read() {
     if [[ -f "${answers_directory}/${next_read}" ]]; then
         value=$(cat ${answers_directory}/${next_read})
     fi
-    eval "export ${1}=${value}"
+    eval "export ${1}=\"${value}\""
     echo ""
 }
 


### PR DESCRIPTION
If there is `gpg` program available, Elegant Git will try to configure
signing for the Git objects during execution of `acquire-repository`
command.

#11

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
