### PR TITLE
Start work from the alternative branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,9 @@ In order to get the documentation preview locally, please install required depen
 
 The [docs/commands.md](docs/commands.md) generates by running `./workflows generate-docs` script.
 All other files in ["docs" directory](docs/) require manual corrections.
+
+### Completions testing
+1. source updated competion file
+    - bash: `source completions/git-elegant.bash`
+    - zsh: `source completions/_git-elegant`
+2. run `git-elegant <some>` and press Tab twice

--- a/completions/_git-elegant
+++ b/completions/_git-elegant
@@ -61,6 +61,7 @@ __ge_complete_commands () {
     case ${line[1]} in
         accept-work|obtain-work)    __ge_remotes ;;
         show-release-notes)         __ge_show_release_notes ;;
+        start-work)                 __ge_start_work ;;
         *)  _arguments '--help' '--no-workflows'  ;;
     esac
 }
@@ -92,4 +93,14 @@ __ge_show_release_notes() {
                '1:mode:__ge_show_release_notes_modes' \
                '2:from:(${all[@]})' \
                '3:to:(${all[@]})'
+}
+
+__ge_start_work() {
+    local all=(
+        $(git for-each-ref --sort '-version:refname' --format '%(refname:short)' refs 2>/dev/null)
+    )
+    _arguments '--help' \
+               '--no-workflows' \
+               '1:name:()' \
+               '2:from:(${all[@]})'
 }

--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -22,7 +22,7 @@ _git_elegant() {
                     $(git elegant show-commands)
                 )
                 COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-                return 0 ;;
+                ;;
             accept-work|obtain-work)
                 local opts=(
                     ${gecops}
@@ -31,25 +31,25 @@ _git_elegant() {
                 COMPREPLY=(
                     $(compgen -W "${opts[*]}" -- ${cursor})
                 )
-                return 0 ;;
+                ;;
             show-release-notes)
                 COMPREPLY=( $(compgen -W "simple smart ${gecops[*]}" -- ${cursor}) )
-                return 0 ;;
+                ;;
             *)
                 COMPREPLY=( $(compgen -W "${gecops[*]}" -- ${cursor}) )
-                return 0 ;;
+                ;;
         esac
     fi
 
     # the second word prior to the ${cursor}
     if [[ ${#COMP_WORDS[*]} > $(( 2 + ${offset} )) ]]; then
         case "${COMP_WORDS[COMP_CWORD-$(( 2 + ${offset} ))]}" in
-            show-release-notes)
+            show-release-notes|start-work)
                 local opts=(
                     $(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs 2>/dev/null)
                 )
                 COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-                return 0 ;;
+                ;;
             *)  ;;
         esac
     fi
@@ -62,7 +62,7 @@ _git_elegant() {
                     $(git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs 2>/dev/null)
                 )
                 COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
-                return 0 ;;
+                ;;
             *)  ;;
         esac
     fi

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -368,12 +368,14 @@ git stash list
 # `start-work`
 
 ```bash
-usage: git elegant start-work <name>
+usage: git elegant start-work <name> [from-ref]
 ```
 
 Creates a new local branch based on the latest version of the default upstream
 branch. If there are some uncommitted changes, they will be moved to the new
 branch.
+
+`from-ref` argument overrides the default upstream branch with a given one.
 
 The command uses stash pipe to preserve the current Git state prior to execution
 and restore after.

--- a/libexec/git-elegant-prune-repository
+++ b/libexec/git-elegant-prune-repository
@@ -41,20 +41,17 @@ The command works even if the remotes are unavailable.
 MESSAGE
 }
 
---is-there-upstream-for() {
-    git rev-parse --abbrev-ref ${1}@{upstream} >/dev/null  2>&1
-}
-
 default() {
+    source ${BINS}/plugins/state
     git-verbose checkout ${MASTER}
-    if --is-there-upstream-for ${MASTER}; then
+    if is-there-upstream-for ${MASTER}; then
         git-verbose fetch --all || info-text "As the remotes can't be fetched, the current local version is used."
         git-verbose rebase
     fi
     for branch in $(git for-each-ref --format "%(refname:short)" refs/heads); do
         if [[ ${branch} == ${MASTER} ]]; then continue; fi
         if [[ -n $(git config --get branch.${branch}.merge) ]]; then
-            if --is-there-upstream-for ${branch}; then
+            if is-there-upstream-for ${branch}; then
                 # the branch has existing upstream; keep it
                 continue
             fi

--- a/libexec/git-elegant-start-work
+++ b/libexec/git-elegant-start-work
@@ -9,7 +9,7 @@ MESSAGE
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant start-work <name>
+usage: git elegant start-work <name> [from-ref]
 MESSAGE
 }
 
@@ -18,6 +18,8 @@ command-description() {
 Creates a new local branch based on the latest version of the default upstream
 branch. If there are some uncommitted changes, they will be moved to the new
 branch.
+
+\`from-ref\` argument overrides the default upstream branch with a given one.
 
 The command uses stash pipe to preserve the current Git state prior to execution
 and restore after.
@@ -38,8 +40,12 @@ MESSAGE
 }
 
 --start-work-logic(){
-    git-verbose checkout ${MASTER}
-    git-verbose pull || info-text "As the branch can't be pulled, the current local version is used."
+    source ${BINS}/plugins/state
+    local target=${2:-${MASTER}}
+    git-verbose checkout ${target}
+    if is-there-upstream-for ${target}; then
+        git-verbose pull
+    fi
     git-verbose checkout -b "$1"
 }
 

--- a/libexec/plugins/state
+++ b/libexec/plugins/state
@@ -28,3 +28,8 @@ last-tag() {
     # Seeks for the last created tag.
     git for-each-ref --sort "-version:refname" --format "%(refname:short)" refs/tags --count 1
 }
+
+is-there-upstream-for() {
+    # usage: is-there-upstream-for <branch ref>
+    git rev-parse --abbrev-ref ${1}@{upstream} >/dev/null 2>&1
+}


### PR DESCRIPTION
Sometimes a new work should be started from the non-master branch. And
this is implemented by adding a second optional argument to
`start-work` command. Also, internal logic has an enhancement that
allows pulling only for branches that have configured remote tracking.

The completion scrips complete the second argument of the command. And
short instructions on how to test the completion updates are added to
README.md.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
