### PR TITLE
Support offline mode for `start-work`

### DIFF
--- a/libexec/git-elegant-start-work
+++ b/libexec/git-elegant-start-work
@@ -44,7 +44,7 @@ MESSAGE
     local target=${2:-${MASTER}}
     git-verbose checkout ${target}
     if is-there-upstream-for ${target}; then
-        git-verbose pull
+        git-verbose pull || info-text "As the pull can't be completed, the current local version is used."
     fi
     git-verbose checkout -b "$1"
 }

--- a/tests/git-elegant-start-work.bats
+++ b/tests/git-elegant-start-work.bats
@@ -23,7 +23,8 @@ teardown() {
     fake-fail "git pull"
     fake-pass "git rev-parse --abbrev-ref master@{upstream}"
     check git-elegant start-work test-feature
-    [[ ${status} -eq 100 ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "As the pull can't be completed, the current local version is used." ]]
 }
 
 @test "'start-work': raises 45 error if work name is not set" {


### PR DESCRIPTION
Sometimes the remote repo can be unavailable when a new work starts.
That's why the execution of `start-work` should be continued regardless
of `git pull` execution status.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
