### PR TITLE
Support local branches in `accept-work` command

### DIFF
--- a/completions/_git-elegant
+++ b/completions/_git-elegant
@@ -59,7 +59,8 @@ __ge_complete_commands () {
     # update this function if a new command requires a competion
     # default completion is empty
     case ${line[1]} in
-        accept-work|obtain-work)    __ge_remotes ;;
+        obtain-work)                __ge_remotes ;;
+        accept-work)                __ge_all_branches ;;
         show-release-notes)         __ge_show_release_notes ;;
         start-work)                 __ge_start_work ;;
         *)  _arguments '--help' '--no-workflows'  ;;
@@ -74,6 +75,16 @@ __ge_remotes() {
     _arguments '--help' \
                '--no-workflows' \
                '1:branch:(${remotes[@]})'
+}
+
+__ge_all_branches() {
+    # completes first position with all available branches
+    local branches=(
+        $(git branch --all --format='%(refname:short)')
+    )
+    _arguments '--help' \
+               '--no-workflows' \
+               '1:branch:(${branches[@]})'
 }
 
 __ge_show_release_notes_modes(){

--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -23,10 +23,19 @@ _git_elegant() {
                 )
                 COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cursor}) )
                 ;;
-            accept-work|obtain-work)
+            obtain-work)
                 local opts=(
                     ${gecops}
                     $(git for-each-ref --format='%(refname:short)' refs/remotes 2>/dev/null)
+                )
+                COMPREPLY=(
+                    $(compgen -W "${opts[*]}" -- ${cursor})
+                )
+                ;;
+            accept-work)
+                local opts=(
+                    ${gecops}
+                    $(git branch --all --format='%(refname:short)')
                 )
                 COMPREPLY=(
                     $(compgen -W "${opts[*]}" -- ${cursor})

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,7 +30,7 @@ There are commands used in various situations such as
 
  operate a flow of work management
     obtain-work          Checkouts a remote branch matching by a name.
-    accept-work          Applies a branch on top of `master` branch.
+    accept-work          Incorporates a branch on top of the `master`.
 
  release new versions
     show-release-notes   Prints a release log between two references.
@@ -48,17 +48,18 @@ Please visit https://elegant-git.bees-hive.org to find out more.
 # `accept-work`
 
 ```bash
-usage: git elegant accept-work <remote branch>
+usage: git elegant accept-work <branch>
 ```
 
-Checkouts given branch using `git elegant obtain-work` into a temporary one.
-Then, it makes a rebase of the latest version of default upstream branch
-(`master`) with current changes. If there is a rebase in progress and it is
-initiated by this command, it will be continued instead. The final rebased index
-merges using fast-forward strategy into the default local branch and pushes into
-the default upstream branch (`origin/master`). After a successful push, the
-temporary branch is removed as well as given branch if it locates in `origin`
-remote.
+Checkouts a given local or remote branch into a temporary one. Then, it makes
+a rebase of the latest version of the default upstream branch (`master`) with
+current changes. The final rebased index merges using fast-forward strategy
+into the default local branch and pushes into the default upstream branch
+(`origin/master`). After a successful push, the temporary branch is removed
+as well as the given branch if it locates in `origin` remote.
+
+If there is a rebase in progress and it is initiated by this command, it will
+be continued instead; otherwise, the command stops.
 
 The command uses branch and stash pipes to preserve the current Git state prior
 to execution and restore after.
@@ -68,7 +69,6 @@ Approximate commands flow is
 ==>> git elegant accept-work task-123
 git fetch --all
 git checkout --force -B __eg origin/task-123
-git status
 git rebase origin/master
 git checkout master
 git merge --ff-only __eg

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -3,26 +3,27 @@ set -e
 
 command-purpose() {
     cat <<MESSAGE
-Applies a branch on top of \`master\` branch.
+Incorporates a branch on top of the \`master\`.
 MESSAGE
 }
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant accept-work <remote branch>
+usage: git elegant accept-work <branch>
 MESSAGE
 }
 
 command-description() {
     cat<<MESSAGE
-Checkouts given branch using \`git elegant obtain-work\` into a temporary one.
-Then, it makes a rebase of the latest version of default upstream branch
-(\`master\`) with current changes. If there is a rebase in progress and it is
-initiated by this command, it will be continued instead. The final rebased index
-merges using fast-forward strategy into the default local branch and pushes into
-the default upstream branch (\`origin/master\`). After a successful push, the
-temporary branch is removed as well as given branch if it locates in \`origin\`
-remote.
+Checkouts a given local or remote branch into a temporary one. Then, it makes
+a rebase of the latest version of the default upstream branch (\`master\`) with
+current changes. The final rebased index merges using fast-forward strategy
+into the default local branch and pushes into the default upstream branch
+(\`origin/master\`). After a successful push, the temporary branch is removed
+as well as the given branch if it locates in \`origin\` remote.
+
+If there is a rebase in progress and it is initiated by this command, it will
+be continued instead; otherwise, the command stops.
 
 The command uses branch and stash pipes to preserve the current Git state prior
 to execution and restore after.
@@ -32,7 +33,6 @@ Approximate commands flow is
 ==>> git elegant accept-work task-123
 git fetch --all
 git checkout --force -B __eg origin/task-123
-git status
 git rebase origin/master
 git checkout master
 git merge --ff-only __eg
@@ -44,28 +44,40 @@ MESSAGE
 }
 
 --accept-work-logic() {
-    local WORK_BRANCH="__eg"
+    local work_branch="__eg"
+    local changes=${1}
     source ${BINS}/plugins/state
     if is-there-active-rebase; then
         local rb=$(rebasing-branch)
-        if [[ ${WORK_BRANCH} == ${rb} ]]; then
+        if [[ ${work_branch} == ${rb} ]]; then
             git-verbose rebase --continue
         else
             error-text "First, please complete current rebase which updates '${rb}' branch."
             exit 43
         fi
     else
-        git elegant obtain-work "${1}" "${WORK_BRANCH}"
-        git-verbose status
-        git-verbose rebase ${RMASTER}
+        _error-if-empty "${changes}" "Please provide a branch name."
+        if git rev-parse --verify --quiet --abbrev-ref --branches=refs/heads ${changes} >/dev/null; then
+            git-verbose fetch --all
+            git-verbose checkout -B ${work_branch} ${changes}
+        else
+            git elegant obtain-work "${changes}" "${work_branch}"
+        fi
+        if are-there-remotes; then
+            git-verbose rebase ${RMASTER}
+        else
+            git-verbose rebase ${MASTER}
+        fi
     fi
-    local ACTUAL_REMOTE=$(git for-each-ref --format='%(upstream:short)' refs/heads/${WORK_BRANCH})
+    local actual_remote=$(git for-each-ref --format='%(upstream:short)' refs/heads/${work_branch})
     git-verbose checkout ${MASTER}
-    git-verbose merge --ff-only ${WORK_BRANCH}
-    git-verbose push ${REMOTE_NAME} ${MASTER}:${MASTER}
-    git-verbose branch --delete --force ${WORK_BRANCH}
-    if [[ ${ACTUAL_REMOTE} =~ ^origin/ ]];  then
-        git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-reference ${ACTUAL_REMOTE})
+    git-verbose merge --ff-only ${work_branch}
+    git-verbose branch --delete --force ${work_branch}
+    if are-there-remotes; then
+        git-verbose push ${REMOTE_NAME} ${MASTER}:${MASTER}
+        if [[ ${actual_remote} =~ ^origin/ ]];  then
+            git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-reference ${actual_remote})
+        fi
     fi
 }
 

--- a/libexec/plugins/state
+++ b/libexec/plugins/state
@@ -33,3 +33,11 @@ is-there-upstream-for() {
     # usage: is-there-upstream-for <branch ref>
     git rev-parse --abbrev-ref ${1}@{upstream} >/dev/null 2>&1
 }
+
+are-there-remotes() {
+    local remotes=$(git remote)
+    if test -z ${remotes}; then
+        return 1
+    fi
+    return 0
+}

--- a/tests/git-elegant-accept-work.bats
+++ b/tests/git-elegant-accept-work.bats
@@ -9,7 +9,6 @@ setup() {
     repo "git checkout -b __eg; git checkout -"
     fake-pass "git elegant obtain-work test-feature __eg"
     fake-pass "git rebase origin/master"
-    fake-pass "git fetch --all"
     fake-pass "git push origin master:master"
 }
 
@@ -18,21 +17,24 @@ teardown() {
     fake-clean
 }
 
-@test "'accept-work': a work is accepted successfully for given remote branch" {
+@test "'accept-work': accepts changes from given remote branch successfully" {
+    fake-pass "git remote" "origin"
     fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
     fake-fail "git push origin --delete test-feature"
     check git-elegant accept-work test-feature
     [[ ${status} -eq 100 ]]
 }
 
-@test "'accept-work': exit code is 45 when remote branch name isn't set" {
+@test "'accept-work': stops with exit code 45 when a branch name isn't set" {
+    fake-pass "git remote" "origin"
     check git-elegant accept-work
     [[ ${status} -eq 45 ]]
 }
 
-@test "'accept-work': save WIP prior accepting and restore after it" {
+@test "'accept-work': saves WIP prior to doing work and restores it after work is done" {
     repo "git checkout -b other"
     repo-non-staged-change "A new line..."
+    fake-pass "git remote" "origin"
     fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin/test-feature"
     fake-pass "git push origin --delete test-feature"
     check git-elegant accept-work test-feature
@@ -42,14 +44,28 @@ teardown() {
     [[ ${lines[@]} =~ "git checkout other" ]]
 }
 
-@test "'accept-work': a remote branch is not removed when it is pulled from fork" {
+@test "'accept-work': does not remove a remote branch that is pulled from a fork" {
     fake-pass "git for-each-ref --format='%(upstream:short)' refs/heads/__eg}" "origin-a/test-feature"
+    fake-pass "git remote" "origin"
     fake-fail "git push origin --delete test-feature"
     check git-elegant accept-work test-feature
     [[ ${status} -eq 0 ]]
 }
 
-@test "'accept-work': continue current rebase when it is initiated by 'accept-work' command" {
+@test "'accept-work': accepts changes from given local branch successfully" {
+    repo "git checkout -b local-work; git checkout -"
+    check git-elegant accept-work local-work
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git fetch --all" ]]
+    [[ ${lines[@]} =~ "git checkout -B __eg local-work" ]]
+    [[ ${lines[@]} =~ "git rebase master" ]]
+    [[ ${lines[@]} =~ "git checkout master" ]]
+    [[ ${lines[@]} =~ "git merge --ff-only __eg" ]]
+    [[ ${lines[@]} =~ "git branch --delete --force __eg" ]]
+    [[ ! ${lines[@]} =~ "git push" ]]
+}
+
+@test "'accept-work': continues current rebase if it was started by 'accept-work' command" {
     repo "git checkout __eg"
     fake-pass "git rev-parse --git-path rebase-merge" ".git"
     repo "echo refs/heads/__eg > .git/head-name"
@@ -58,7 +74,7 @@ teardown() {
     [[ ${lines[@]} =~ "No rebase in progress?" ]]
 }
 
-@test "'accept-work': raise error 43 when current rebase is not initiated by 'accept-work' command" {
+@test "'accept-work': stops with exit code 43 if current rebase was not started by 'accept-work' command" {
     repo "git checkout __eg"
     fake-pass "git rev-parse --git-path rebase-merge" ".git"
     repo "echo refs/heads/rebase > .git/head-name"


### PR DESCRIPTION
There are at least two cases when a user needs to incorporate work from
a local branch into the current upstream:
1. there is no a remote repository; a user uses git locally
2. there is a remote repository, but a user wants just accept local
   branch with appropriate update of the remote upstream

Now these cases are supported by `accept-work` command. Also,
completions provide a full list of branches (not only remotes) now.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
