### PR TITLE
Unify the assertions look for all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,17 @@ Also, there are several optional addons which can be useful in some circumstance
 5. Do not fake `git-elegant` commands within the tests.
 
 #### Assertions
-- `[[ "${lines[0]}" = "+ the space " ]]` for an output line (index starts from 0)
-- `[[ "$status" -eq 2 ]]` for a command status
-- `[[ "${#lines[@]}" -eq 0 ]]` for a length of command output
-- `[[ "${lines[@]}" =~ "exact string" ]]` for an output line within whole output
+- `[[ ${status} -eq 2 ]]` for a command status
+- `[[ ${#lines[@]} -eq 0 ]]` for a length of command output
+- `[[ ${lines[0]} = "+ the space " ]]` for an output line (index starts from 0)
+- `[[ ${lines[@]} =~ "exact string" ]]` for an output line within whole output
 
 #### Test name template
-Use the following test name template - `'<command args>': <describe what will be tested>` like
-`'clone-repository': raise an error if cloneable URL isn't set`.
+Use the following test name template - `'<command>': <describes the behavior that will be tested>`
+like `'clone-repository': stops with exit code 45 if cloneable URL is not set`.
+
+The behavior should be descriptive-style (`stops with exit code 45 if cloneable URL is not set`)
+rather than imperative-style (`stop with exit code 45 if cloneable URL is not set`).
 
 ### Updating documentation
 In order to get the documentation preview locally, please install required dependencies with 

--- a/tests/git-elegant-acquire-git.bats
+++ b/tests/git-elegant-acquire-git.bats
@@ -18,73 +18,73 @@ teardown() {
 
 @test "'acquire-git': all configurations work as expected" {
     check git-elegant acquire-git
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'acquire-git': basics are configured as expected" {
     check git-elegant acquire-git
-    [[ "${lines[@]}" =~ "Please hit enter if you wish {default value}." ]]
-    [[ "${lines[@]}" =~ "What is your user name? {Elegant Git}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --global user.name Elegant Git" ]]
-    [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --global user.email elegant-git@example.com" ]]
-    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.editor vi" ]]
+    [[ ${lines[@]} =~ "Please hit enter if you wish {default value}." ]]
+    [[ ${lines[@]} =~ "What is your user name? {Elegant Git}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --global user.name Elegant Git" ]]
+    [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --global user.email elegant-git@example.com" ]]
+    [[ ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.editor vi" ]]
 }
 
 @test "'acquire-git': standards are configured as expected on Windows" {
     fake-pass "uname -s" Windows
     check git-elegant acquire-git
-    [[ "${lines[@]}" =~ "==>> git config --global core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.autocrlf true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global rebase.autoStash false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global elegant.acquired true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --global apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.autocrlf true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global elegant.acquired true" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --global credential.helper osxkeychain" ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --global core.autocrlf input" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global credential.helper osxkeychain" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global core.autocrlf input" ]]
 }
 
 @test "'acquire-git': standards are configured as expected on Linux" {
     fake-pass "uname -s" Linux
     check git-elegant acquire-git
-    [[ "${lines[@]}" =~ "==>> git config --global core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.autocrlf input" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global rebase.autoStash false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global elegant.acquired true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --global apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.autocrlf input" ]]
+    [[ ${lines[@]} =~ "==>> git config --global pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global elegant.acquired true" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --global credential.helper osxkeychain" ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --global core.autocrlf true" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global credential.helper osxkeychain" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global core.autocrlf true" ]]
 }
 
 @test "'acquire-git': standards are configured as expected on Darwin" {
     fake-pass "uname -s" Darwin
     check git-elegant acquire-git
-    [[ "${lines[@]}" =~ "==>> git config --global core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.autocrlf input" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global rebase.autoStash false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global credential.helper osxkeychain" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global elegant.acquired true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --global apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.autocrlf input" ]]
+    [[ ${lines[@]} =~ "==>> git config --global pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --global rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --global credential.helper osxkeychain" ]]
+    [[ ${lines[@]} =~ "==>> git config --global elegant.acquired true" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --global core.autocrlf true" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global core.autocrlf true" ]]
 }
 
 @test "'acquire-git': new aliases are configured as expected" {
     check git-elegant acquire-git
     for next in $(git-elegant show-commands); do
         echo "Test aliasing of '${next}' command"
-        [[ "${lines[@]}" =~ "==>> git config --global alias.${next} elegant ${next}" ]]
+        [[ ${lines[@]} =~ "==>> git config --global alias.${next} elegant ${next}" ]]
         echo "Tested successfully!"
     done
 }
@@ -93,16 +93,16 @@ teardown() {
     repo git config --global "alias.aaa" "\"elegant aaa\""
     repo git config --global "alias.bbb" "\"elegant bbb\""
     check git-elegant acquire-git
-    [[ "$status" -eq 0 ]]
-    [[ "${lines[@]}" =~ "2 Elegant Git aliases were removed." ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "2 Elegant Git aliases were removed." ]]
 }
 
 @test "'acquire-git': a message is displayed if global configuration is disabled" {
     read-clean
     read-answer "n"
     check git-elegant acquire-git
-    [[ "$status" -eq 0 ]]
-    [[ "${lines[@]}" =~ "You've decided to stay with local configurations. Great!" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "You've decided to stay with local configurations. Great!" ]]
 }
 
 @test "'acquire-git': the basics are not changed if they are already configured" {
@@ -110,9 +110,9 @@ teardown() {
     repo git config --global user.email aaaa
     repo git config --global core.editor aaaa
     check git-elegant acquire-git
-    [[ "$status" -eq 0 ]]
-    [[ "${lines[@]}" =~ "==>> git config --global user.name aaaa" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global user.email aaaa" ]]
-    [[ "${lines[@]}" =~ "==>> git config --global core.editor aaaa" ]]
-    [[ ! "${lines[@]}" =~ "Please hit enter if you wish {default value}." ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "==>> git config --global user.name aaaa" ]]
+    [[ ${lines[@]} =~ "==>> git config --global user.email aaaa" ]]
+    [[ ${lines[@]} =~ "==>> git config --global core.editor aaaa" ]]
+    [[ ! ${lines[@]} =~ "Please hit enter if you wish {default value}." ]]
 }

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -18,69 +18,69 @@ teardown() {
 
 @test "'acquire-repository': all configurations work as expected" {
     check git-elegant acquire-repository
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'acquire-repository': basics are configured as expected" {
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "What is your user name? {Elegant Git}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local user.name Elegant Git" ]]
-    [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local user.email elegant-git@example.com" ]]
-    [[ "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local core.editor vi" ]]
+    [[ ${lines[@]} =~ "What is your user name? {Elegant Git}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local user.name Elegant Git" ]]
+    [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local user.email elegant-git@example.com" ]]
+    [[ ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.editor vi" ]]
 }
 
 @test "'acquire-repository': standards are configured as expected on Windows" {
     fake-pass "uname -s" Windows
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "==>> git config --local core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local core.autocrlf true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --local apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.autocrlf true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local rebase.autoStash false" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --local credential.helper osxkeychain" ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.autocrlf input" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local credential.helper osxkeychain" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local core.autocrlf input" ]]
 }
 
 @test "'acquire-repository': standards are configured as expected on Linux" {
     fake-pass "uname -s" Linux
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "==>> git config --local core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local core.autocrlf input" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --local apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.autocrlf input" ]]
+    [[ ${lines[@]} =~ "==>> git config --local pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local rebase.autoStash false" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --local credential.helper osxkeychain" ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.autocrlf true" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local credential.helper osxkeychain" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local core.autocrlf true" ]]
 }
 
 @test "'acquire-repository': standards are configured as expected on Darwin" {
     fake-pass "uname -s" Darwin
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "==>> git config --local core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local apply.whitespace fix" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.prune true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local fetch.pruneTags false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local core.autocrlf input" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local pull.rebase true" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local rebase.autoStash false" ]]
-    [[ "${lines[@]}" =~ "==>> git config --local credential.helper osxkeychain" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.commentChar |" ]]
+    [[ ${lines[@]} =~ "==>> git config --local apply.whitespace fix" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.prune true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local fetch.pruneTags false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.autocrlf input" ]]
+    [[ ${lines[@]} =~ "==>> git config --local pull.rebase true" ]]
+    [[ ${lines[@]} =~ "==>> git config --local rebase.autoStash false" ]]
+    [[ ${lines[@]} =~ "==>> git config --local credential.helper osxkeychain" ]]
     # negative checks are used instead of checking commands size
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.autocrlf true" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local core.autocrlf true" ]]
 }
 
 @test "'acquire-repository': new aliases are configured as expected" {
     check git-elegant acquire-repository
     for next in $(git-elegant show-commands); do
         echo "Test aliasing of '${next}' command"
-        [[ "${lines[@]}" =~ "==>> git config --local alias.${next} elegant ${next}" ]]
+        [[ ${lines[@]} =~ "==>> git config --local alias.${next} elegant ${next}" ]]
         echo "Tested successfully!"
     done
 }
@@ -89,8 +89,8 @@ teardown() {
     repo git config --local "alias.aaa" "\"elegant aaa\""
     repo git config --local "alias.bbb" "\"elegant bbb\""
     check git-elegant acquire-repository
-    [[ "$status" -eq 0 ]]
-    [[ "${lines[@]}" =~ "2 Elegant Git aliases were removed." ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "2 Elegant Git aliases were removed." ]]
 }
 
 @test "'acquire-repository': 'elegant.acquired' affects configuration correctly" {
@@ -99,15 +99,15 @@ teardown() {
     repo git config --global "alias.bbb" "\"elegant bbb\""
     repo git config --global "elegant.acquired" "true"
     check git-elegant acquire-repository
-    [[ "${lines[@]}" =~ "What is your user name? {Elegant Git}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local user.name Elegant Git" ]]
-    [[ "${lines[@]}" =~ "What is your user email? {elegant-git@example.com}: " ]]
-    [[ "${lines[@]}" =~ "==>> git config --local user.email elegant-git@example.com" ]]
-    [[ ! "${lines[@]}" =~ "Please specify a command to start the editor. {vi}: " ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.editor vi" ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local core.commentChar |" ]]
-    [[ "${lines[@]}" =~ "1 Elegant Git aliases were removed." ]]
-    [[ ! "${lines[@]}" =~ "==>> git config --local alias.acquire-repository elegant acquire-repository" ]]
+    [[ ${lines[@]} =~ "What is your user name? {Elegant Git}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local user.name Elegant Git" ]]
+    [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local user.email elegant-git@example.com" ]]
+    [[ ! ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local core.editor vi" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local core.commentChar |" ]]
+    [[ ${lines[@]} =~ "1 Elegant Git aliases were removed." ]]
+    [[ ! ${lines[@]} =~ "==>> git config --local alias.acquire-repository elegant acquire-repository" ]]
 }
 
 @test "'acquire-repository': configures a signature if GPG key is provided" {

--- a/tests/git-elegant-amend-work.bats
+++ b/tests/git-elegant-amend-work.bats
@@ -20,12 +20,12 @@ teardown() {
     fake-pass "git commit --amend"
     repo git checkout -b test
     check git-elegant amend-work
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'amend-work': exit code is 42 when current local branch is master" {
     check git-elegant amend-work
-    [[ "${status}" -eq 42 ]]
-    [[ "${lines[@]}" =~ "== No commits to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
-    [[ "${lines[@]}" =~ "== Try 'git elegant start-work' prior to retrying this command. ==" ]]
+    [[ ${status} -eq 42 ]]
+    [[ ${lines[@]} =~ "== No commits to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
+    [[ ${lines[@]} =~ "== Try 'git elegant start-work' prior to retrying this command. ==" ]]
 }

--- a/tests/git-elegant-clone-repository.bats
+++ b/tests/git-elegant-clone-repository.bats
@@ -16,12 +16,13 @@ teardown() {
     fake-clean
 }
 
-@test "'clone-repository': raise an error if cloneable URL isn't set" {
-  check git-elegant clone-repository
-  [[ "${lines[0]}" =~ "Cloneable URL is not set"  ]]
+@test "'clone-repository': stops with exit code 45 if cloneable URL is not set" {
+    check git-elegant clone-repository
+    [[ ${status} -eq 45 ]]
+    [[ ${lines[0]} =~ "Cloneable URL is not set" ]]
 }
 
 @test "'clone-repository': clone the repo" {
-  check git-elegant clone-repository https://github.com/extsoft/elegant-git.git
-  [ "$status" -eq 0 ]
+    check git-elegant clone-repository https://github.com/extsoft/elegant-git.git
+    [[ ${status} -eq 0 ]]
 }

--- a/tests/git-elegant-deliver-work.bats
+++ b/tests/git-elegant-deliver-work.bats
@@ -20,22 +20,22 @@ teardown() {
     repo "git checkout -b feature1"
     fake-pass "git push --set-upstream --force origin feature1:feature1"
     check git-elegant deliver-work
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature1" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git push --set-upstream --force origin feature1:feature1" ]]
 }
 
 @test "'deliver-work': if branch name passed, a name of remote branch is different to local branch" {
     repo "git checkout -b feature1"
     fake-pass "git push --set-upstream --force origin feature1:feature2"
     check git-elegant deliver-work feature2
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "git push --set-upstream --force origin feature1:feature2" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git push --set-upstream --force origin feature1:feature2" ]]
 }
 
 @test "'deliver-work': exit code is 42 when current local branch is master" {
     check git-elegant deliver-work
-    [[ "${status}" -eq 42 ]]
-    [[ "${lines[1]}" = "== No pushes to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
+    [[ ${status} -eq 42 ]]
+    [[ ${lines[1]} = "== No pushes to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
 }
 
 @test "'deliver-work': use stash pipe if there are uncommitted changes" {
@@ -43,9 +43,9 @@ teardown() {
     repo-non-staged-change "A new line..."
     fake-pass "git push --set-upstream --force origin feature1:feature1"
     check git-elegant deliver-work
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "git stash push" ]]
-    [[ "${lines[@]}" =~ "git stash pop" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git stash push" ]]
+    [[ ${lines[@]} =~ "git stash pop" ]]
 }
 
 @test "'deliver-work': use existing upstream branch if it is available" {
@@ -54,8 +54,8 @@ teardown() {
     repo "git branch --set-upstream-to some/remote"
     fake-pass "git push --set-upstream --force some feature1:remote"
     check git-elegant deliver-work
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "git push --set-upstream --force some feature1:remote" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git push --set-upstream --force some feature1:remote" ]]
 }
 
 @test "'deliver-work': open URls if they are present in the push output" {
@@ -63,7 +63,7 @@ teardown() {
     fake-pass "git push --set-upstream --force origin feature1:feature1" "remote: https://pull/new/some"
     fake "open https://pull/new/some" 23
     check git-elegant deliver-work
-    [[ "${status}" -eq 23 ]]
+    [[ ${status} -eq 23 ]]
 }
 
 @test "'deliver-work': exit 0 if URls are not present in the push output" {
@@ -71,7 +71,7 @@ teardown() {
     fake-pass "git push --set-upstream --force origin feature1:feature1" "Branch 'workflows' set up to track remote branch 'workflows' from 'origin'."
     fake "open https://pull/new/some" 23
     check git-elegant deliver-work
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'deliver-work': current rebase is continued when there is an active rebase process" {

--- a/tests/git-elegant-obtain-work.bats
+++ b/tests/git-elegant-obtain-work.bats
@@ -9,8 +9,8 @@ teardown() {
 
 @test "'obtain-work': raise 45 error if branch name pattern in not set" {
     check git-elegant obtain-work
-    [[ "$status" -eq 45 ]]
-    [[ "${lines[@]}" =~ "Please provide a branch name or its part." ]]
+    [[ ${status} -eq 45 ]]
+    [[ ${lines[@]} =~ "Please provide a branch name or its part." ]]
 }
 
 @test "'obtain-work': use found remote branch when given pattern matches only one remote branch" {
@@ -19,7 +19,7 @@ teardown() {
     fake-pass "git checkout -B rremote origin/rremote"
 
     check git-elegant obtain-work rr
-    [[ "$status" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'obtain-work': use given local branch name when it is provided" {
@@ -28,7 +28,7 @@ teardown() {
     fake-pass "git checkout -B myname origin/rremote"
 
     check git-elegant obtain-work rr myname
-    [[ "$status" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'obtain-work': raise 43 error when given pattern matches several remote branches" {
@@ -36,8 +36,8 @@ teardown() {
     fake-pass "git for-each-ref --format='%(refname:short)' refs/remotes" "origin/rremote\norigin/master\nother-upstream/barr"
 
     check git-elegant obtain-work rr
-    [[ "$status" -eq 43 ]]
-    [[ "${lines[@]}" =~ "Please re-run the command with concrete branch name from the list above!" ]]
+    [[ ${status} -eq 43 ]]
+    [[ ${lines[@]} =~ "Please re-run the command with concrete branch name from the list above!" ]]
 }
 
 @test "'obtain-work': raise 43 error when given pattern matches zero remote branches" {
@@ -45,6 +45,6 @@ teardown() {
     fake-pass "git for-each-ref --format='%(refname:short)' refs/remotes" "origin/rremote\norigin/master\norigin/barr"
 
     check git-elegant obtain-work aa
-    [[ "$status" -eq 43 ]]
-    [[ "${lines[@]}" =~ "There is no branch that matches the 'aa' pattern." ]]
+    [[ ${status} -eq 43 ]]
+    [[ ${lines[@]} =~ "There is no branch that matches the 'aa' pattern." ]]
 }

--- a/tests/git-elegant-polish-work.bats
+++ b/tests/git-elegant-polish-work.bats
@@ -15,14 +15,14 @@ teardown() {
 
 @test "'polish-work': exit code is 42 when the command is run against 'master' branch" {
     check git-elegant polish-work
-    [[ "${status}" -eq 42 ]]
+    [[ ${status} -eq 42 ]]
 }
 
 @test "'polish-work': a rebase process doesn't start when there are no new commits" {
     repo "git checkout -b no-new-commits"
     check git-elegant polish-work
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "There are no new commits comparing to 'master' branch." ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "There are no new commits comparing to 'master' branch." ]]
 }
 
 @test "'polish-work': a rebase process works when there are new commits" {
@@ -32,7 +32,7 @@ teardown() {
     repo-commit-file "3"
     fake-fail "git rebase --interactive @~3" "git rebase was executed"
     check git-elegant polish-work
-    [[ "${status}" -eq 100 ]]
+    [[ ${status} -eq 100 ]]
     [[ ${lines[@]} =~ "git rebase was executed" ]]
 }
 
@@ -40,7 +40,7 @@ teardown() {
     repo "git checkout -b new-commits"
     fake-pass "git rev-parse --git-path rebase-merge" ".git"
     check git-elegant polish-work
-    [[ "${status}" -ne 0 ]]
+    [[ ${status} -ne 0 ]]
     [[ ${lines[@]} =~ "No rebase in progress?" ]]
 }
 
@@ -51,5 +51,5 @@ teardown() {
     fake-pass "git rebase --interactive @~1"
     fake-fail "git stash pop stash@{0}"
     check git-elegant polish-work
-    [[ "$status" -eq 100 ]]
+    [[ ${status} -eq 100 ]]
 }

--- a/tests/git-elegant-release-work.bats
+++ b/tests/git-elegant-release-work.bats
@@ -33,15 +33,15 @@ teardown() {
 
 @test "'release-work': release work when a new tag is provided as argument" {
     check git-elegant release-work ${new_tag}
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "Release notes" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "Release notes" ]]
 }
 
 @test "'release-work': release work when a new tag is provided via question" {
     read-answer ${new_tag}
     check git-elegant release-work
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "Release notes" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "Release notes" ]]
 }
 
 @test "'release-work': working branch is restored when the command runs in non-master branch" {
@@ -64,7 +64,7 @@ teardown() {
 @test "'release-work': creates an annotated tag if there are no other tags" {
     repo "git tag | xargs git tag -d"
     check git-elegant release-work ${new_tag}
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "Release notes" ]]
-    [[ "${lines[@]}" =~ "- Add file" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "Release notes" ]]
+    [[ ${lines[@]} =~ "- Add file" ]]
 }

--- a/tests/git-elegant-save-work.bats
+++ b/tests/git-elegant-save-work.bats
@@ -20,12 +20,12 @@ teardown() {
     fake-pass "git commit"
     repo git checkout -b test
     check git-elegant save-work
-    [[ "${status}" -eq 0 ]]
+    [[ ${status} -eq 0 ]]
 }
 
 @test "'save-work': exit code is 42 when current local branch is master" {
     check git-elegant save-work
-    [[ "${status}" -eq 42 ]]
-    [[ "${lines[@]}" =~ "== No commits to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
-    [[ "${lines[@]}" =~ "== Try 'git elegant start-work' prior to retrying this command. ==" ]]
+    [[ ${status} -eq 42 ]]
+    [[ ${lines[@]} =~ "== No commits to 'master' branch. Please read more on https://elegant-git.bees-hive.org ==" ]]
+    [[ ${lines[@]} =~ "== Try 'git elegant start-work' prior to retrying this command. ==" ]]
 }

--- a/tests/git-elegant-show-commands.bats
+++ b/tests/git-elegant-show-commands.bats
@@ -31,13 +31,13 @@ teardown() {
         "polish-work"
     )
     check git-elegant show-commands
-    [ ${#lines[@]} -eq ${#COMMANDS[@]} ]
+    [[ ${#lines[@]} -eq ${#COMMANDS[@]} ]]
     for command in ${COMMANDS[@]}; do
-        [[ "${lines[@]}" =~ "${command}" ]]
+        [[ ${lines[@]} =~ "${command}" ]]
     done
 }
 
 @test "'show-commands': default exit code is 0" {
     check git-elegant show-commands
-    [ "$status" -eq 0 ]
+    [[ ${status} -eq 0 ]]
 }

--- a/tests/git-elegant-show-release-notes.bats
+++ b/tests/git-elegant-show-release-notes.bats
@@ -26,59 +26,59 @@ teardown() {
 @test "'show-release-notes': the defaults are used when there are no arguments specified" {
     fake-pass "git remote get-url origin" "https://fake-repo.git"
     check git-elegant show-release-notes
-    [[ "${status}" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ${first} ]]
-    [[ ! "${lines[@]}" =~ ${second} ]]
-    [[ "${lines[@]}" =~ ${third} ]]
-    [[ "${#lines[@]}" -eq 2 ]]
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[@]} =~ ${first} ]]
+    [[ ! ${lines[@]} =~ ${second} ]]
+    [[ ${lines[@]} =~ ${third} ]]
+    [[ ${#lines[@]} -eq 2 ]]
 }
 
 @test "'show-release-notes': a 'from-reference' is used when it is specified" {
     fake-pass "git remote get-url origin" "https://fake-repo.git"
     check git-elegant show-release-notes simple 1
-    [[ "${status}" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ${first} ]]
-    [[ "${lines[@]}" =~ ${second} ]]
-    [[ "${lines[@]}" =~ ${third} ]]
-    [[ "${#lines[@]}" -eq 3 ]]
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[@]} =~ ${first} ]]
+    [[ ${lines[@]} =~ ${second} ]]
+    [[ ${lines[@]} =~ ${third} ]]
+    [[ ${#lines[@]} -eq 3 ]]
 }
 
 @test "'show-release-notes': a 'to-reference' is used when it is specified" {
     fake-pass "git remote get-url origin" "https://fake-repo.git"
     check git-elegant show-release-notes simple 1 HEAD
-    [[ "${status}" -eq 0 ]]
-    [[ ! "${lines[@]}" =~ ${first} ]]
-    [[ "${lines[@]}" =~ ${second} ]]
-    [[ "${lines[@]}" =~ ${third} ]]
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[@]} =~ ${first} ]]
+    [[ ${lines[@]} =~ ${second} ]]
+    [[ ${lines[@]} =~ ${third} ]]
 }
 
 @test "'show-release-notes': a GitHub layout is used if 'git@git@github.com' is in remote URL" {
     fake-pass "git remote get-url origin" "git@github.com:bees-hive/elegant-git.git"
     check git-elegant show-release-notes smart 1 @
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
 }
 
 @test "'show-release-notes': a GitHub layout is used if 'https://github.com' is in remote URL" {
     fake-pass "git remote get-url origin" "https://github.com/bees-hive/elegant-git.git"
     check git-elegant show-release-notes smart 1 @
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[@]}" =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "<li> <a href=\"https://github.com/bees-hive/elegant-git" ]]
 }
 
 @test "'show-release-notes': raise error 43 if a given layout is unknown" {
     check git-elegant show-release-notes some
-    [[ "${status}" -eq 43 ]]
-    [[ "${lines[@]}" =~ "'some' layout is not supported." ]]
+    [[ ${status} -eq 43 ]]
+    [[ ${lines[@]} =~ "'some' layout is not supported." ]]
 }
 
 @test "'show-release-notes': displays all commits if there is no tags" {
     repo "git tag | xargs git tag -d"
     check git-elegant show-release-notes
-    [[ "${status}" -eq 0 ]]
-    [[ "${lines[0]}" == "Release notes" ]]
-    [[ "${lines[1]}" == "- Add file" ]]
-    [[ "${lines[2]}" == "- Add ${first}" ]]
-    [[ "${lines[3]}" == "- Add ${second}" ]]
-    [[ "${lines[4]}" == "- Add ${third}" ]]
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[0]} == "Release notes" ]]
+    [[ ${lines[1]} == "- Add file" ]]
+    [[ ${lines[2]} == "- Add ${first}" ]]
+    [[ ${lines[3]} == "- Add ${second}" ]]
+    [[ ${lines[4]} == "- Add ${third}" ]]
 }

--- a/tests/git-elegant.bats
+++ b/tests/git-elegant.bats
@@ -14,22 +14,22 @@ teardown(){
 
 @test "'git elegant': a help is displayed if a command is not provided" {
     check git-elegant
-    [[ "$status" -eq 0 ]]
-    [ ${#lines[@]} -gt 3 ]
+    [[ ${status} -eq 0 ]]
+    [[ ${#lines[@]} -gt 3 ]]
 }
 
 @test "'git elegant': a unknown command is handled in user-friendly way" {
     check git-elegant sdfsdfsd
-    [[ "$status" -eq 46 ]]
-    [[ "${lines[@]}" =~ "Unknown command: git elegant sdfsdfsd" ]]
+    [[ ${status} -eq 46 ]]
+    [[ ${lines[@]} =~ "Unknown command: git elegant sdfsdfsd" ]]
 }
 
 @test "'git elegant': a help is provided for each available command" {
     for COMMAND in $(git-elegant show-commands) ; do
         echo "Check help for '${COMMAND}'"
         check git-elegant ${COMMAND} -h
-        [[ "$status" -eq 0 ]]
-        [ ${#lines[@]} -gt 3 ]
+        [[ ${status} -eq 0 ]]
+        [[ ${#lines[@]} -gt 3 ]]
     done
 }
 
@@ -37,13 +37,13 @@ teardown(){
     check git-elegant --help
     for COMMAND in $(git-elegant show-commands) ; do
         echo "Check presence of '${COMMAND}'"
-        [[ "${lines[@]}" =~ "${COMMAND}" ]]
+        [[ ${lines[@]} =~ "${COMMAND}" ]]
     done
 }
 
 @test "'git elegant': a version is displayed correctly" {
     check git-elegant --version
-    [[ "${lines[@]}" =~ "/eg/tests/../libexec/../version" ]]
+    [[ ${lines[@]} =~ "/eg/tests/../libexec/../version" ]]
 }
 
 @test "'git elegant': workflows are loaded correctly when a command is executed from root directory" {


### PR DESCRIPTION
For consistency, now all tests follow the following:
1. all assertions are in double square quotes like [[ .... ]]
2. left part of the assertions is described without quotes
3. all variables are in ${...} format

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
