### PR TITLE
Open a given workflows file when `polish-workflow`

### DIFF
--- a/libexec/git-elegant-polish-workflow
+++ b/libexec/git-elegant-polish-workflow
@@ -27,10 +27,10 @@ MESSAGE
 
 default() {
     _error-if-empty "${1}" "Please specify a workflow file name"
-    if test -e ${file}; then
-        $(git config core.editor) ${file}
+    if test -e ${1}; then
+        $(git config core.editor) ${1}
     else
-        error-text "The '${file}' file does not exist."
+        error-text "The '${1}' file does not exist."
         exit 43
     fi
 }


### PR DESCRIPTION
There is undefined `${file}` variable that is used as a reference to a
given workflows file. But the variable is never initialized. As the
result, the command just opens the editor, but not a given file. Now,
this variable is replaced with `${1}` (a reference to the first input
parameter).

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
