### PR TITLE
Read multi slash branch names when `deliver-work`

### DIFF
--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -40,11 +40,6 @@ _error-if-empty() {
     fi
 }
 
-branch-from-remote-reference() {
-    # usage: branch-from-remote-reference <full reference name>
-    echo ${1} | sed "s|^[a-zA-Z0-9_-]*/||g"
-}
-
 remove-file() {
     [[ -f ${1} ]] && rm ${1}
 }

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -76,7 +76,8 @@ MESSAGE
     if are-there-remotes; then
         git-verbose push ${REMOTE_NAME} ${MASTER}:${MASTER}
         if [[ ${actual_remote} =~ ^origin/ ]];  then
-            git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-reference ${actual_remote})
+            source ${BINS}/plugins/transformation
+            git-verbose push ${REMOTE_NAME} --delete $(branch-from-remote-branch ${actual_remote})
         fi
     fi
 }

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -52,6 +52,7 @@ MESSAGE
 
 --deliver-work-logic() {
     source ${BINS}/plugins/state
+    source ${BINS}/plugins/transformation
     if is-there-active-rebase; then
         git-verbose rebase --continue
     else
@@ -59,18 +60,18 @@ MESSAGE
         git-verbose rebase ${RMASTER}
     fi
     local upstream=$(git branch --list --format "%(upstream:short)" ${1})
-    local remote_branch=${upstream/*\//}
-    local remote=${upstream/\/*/}
+    local branch=$(branch-from-remote-branch ${upstream})
+    local remote=$(remote-from-remote-branch ${upstream})
     if [[ -n "${2}" ]]; then
-        remote_branch=${2}
+        branch=${2}
     fi
-    if [[ -z "${remote_branch}" ]]; then
-        remote_branch=${1}
+    if [[ -z "${branch}" ]]; then
+        branch=${1}
     fi
     if [[ -z "${remote}" ]]; then
         remote=${REMOTE_NAME}
     fi
-    git-verbose-op --open-urls-if-possible push --set-upstream --force ${remote} ${1}:${remote_branch}
+    git-verbose-op --open-urls-if-possible push --set-upstream --force ${remote} ${1}:${branch}
 }
 
 default() {

--- a/libexec/git-elegant-obtain-work
+++ b/libexec/git-elegant-obtain-work
@@ -48,7 +48,8 @@ default() {
         local REMOTE=${REMOTE_BRANCHES[0]}
         local LOCAL=${2}
         if [[ -z ${LOCAL} ]]; then
-            LOCAL=$(branch-from-remote-reference ${REMOTE})
+            source ${BINS}/plugins/transformation
+            LOCAL=$(branch-from-remote-branch ${REMOTE})
         fi
         git-verbose checkout -B ${LOCAL} ${REMOTE}
     else

--- a/libexec/plugins/transformation
+++ b/libexec/plugins/transformation
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# The plugin holds functions that convert one object into another.
+# The most part of functions manipulates with strings.
+
+branch-from-remote-branch() {
+    # usage : echo $(branch-from-remote-branch origin/feature/a)
+    # result: feature/a
+    echo ${1#*/}
+}
+
+remote-from-remote-branch() {
+    # usage : echo $(remote-from-remote-branch origin/feature/a)
+    # result: origin
+    echo ${1%%/*}
+}

--- a/tests/git-elegant-deliver-work.bats
+++ b/tests/git-elegant-deliver-work.bats
@@ -49,13 +49,13 @@ teardown() {
 }
 
 @test "'deliver-work': use existing upstream branch if it is available" {
-    repo "git checkout -b some/remote"
-    repo "git checkout -b feature1"
-    repo "git branch --set-upstream-to some/remote"
-    fake-pass "git push --set-upstream --force some feature1:remote"
+    repo "git checkout -b some-remote/feature/123"
+    repo "git checkout -b 123"
+    repo "git branch --set-upstream-to some-remote/feature/123"
+    fake-pass "git push --set-upstream --force some-remote 123:feature/123"
     check git-elegant deliver-work
     [[ ${status} -eq 0 ]]
-    [[ ${lines[@]} =~ "git push --set-upstream --force some feature1:remote" ]]
+    [[ ${lines[@]} =~ "git push --set-upstream --force some-remote 123:feature/123" ]]
 }
 
 @test "'deliver-work': open URls if they are present in the push output" {


### PR DESCRIPTION
`git elegant deliver-work` incorrectly reads the name of the upstream
branch if it contains at least one slash like `feature/123`. This is
because the used pattern matching logic doesn't expect remote branch
names like `origin/feature/123`.

In order to solve it, the new `transformation` plugin is introduced. It
provides functions that parse remote branch names correctly. Now, the
plugin handles branch translation (mapping) for `deliver-work` command
as well as for `accept-work` and `obtain-work` in order to prevent
possible errors in the future.

#255

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
