### PR TITLE
Use Bash pattern matching instead of `sed` in `show-commands`

### DIFF
--- a/libexec/git-elegant-show-commands
+++ b/libexec/git-elegant-show-commands
@@ -30,8 +30,9 @@ MESSAGE
 }
 
 default() {
-    local PREFIX="git-elegant-"
-    for FILE in $(ls -1 ${BINS}/${PREFIX}*); do
-        echo $(basename ${FILE} | sed "s/${PREFIX}//")
+    local pattern="git-elegant-*"
+    for command_path in $(ls -1 ${BINS}/${pattern}); do
+        local command_file=$(basename ${command_path})
+        echo ${command_file#${pattern}}
     done
 }


### PR DESCRIPTION
`sed` is replaced with pattern matching in parameter substitution (Bash
language feature) as Elegant Git wants to relay on Git and Bash commands
if possible.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
