### PR TITLE
Prevent "binary operator expected" error

### DIFF
--- a/libexec/plugins/pipe
+++ b/libexec/plugins/pipe
@@ -54,7 +54,7 @@ branch-pipe() {
     # have to add new tests in `git-elegant-release-work.bats` if you want to
     # check some specific cases.
     local key="elegant.${COMMAND}-current-branch"
-    if test -z $(--repository-config --get ${key}); then
+    if test -z "$(--repository-config --get ${key})"; then
         --repository-config ${key} $(git rev-parse --abbrev-ref HEAD)
     fi
 

--- a/libexec/plugins/state
+++ b/libexec/plugins/state
@@ -35,8 +35,7 @@ is-there-upstream-for() {
 }
 
 are-there-remotes() {
-    local remotes=$(git remote)
-    if test -z ${remotes}; then
+    if test -z "$(git remote)"; then
         return 1
     fi
     return 0


### PR DESCRIPTION
`test -z` expects a string argument, otherwise, it raises the "binary
operator expected" error. The easiest way to convert something to a
string is to wrap it in quotes. That's why, in all place, the `test -z`
arguments are wrapped with quotes.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
