### PR TITLE
Print error with a relevant command for docs generation

### DIFF
--- a/.workflows/ci-pipeline.bash
+++ b/.workflows/ci-pipeline.bash
@@ -34,7 +34,7 @@ pipeline() {
         python .workflows/docs.py
         git update-index --really-refresh
         git diff-index --quiet HEAD --
-    ) || fail "The documentation is not up to date. Please run './.workflows/docs-generation.bash' and commit the changes"
+    ) || fail "The documentation is not up to date. Please run 'python .workflows/docs.py' and commit the changes"
 
 }
 


### PR DESCRIPTION
The commit fixes the error message that is displayed if the docs weren't
updated prior to making a commit. The problem is that the command for
documentation generation is wrong. Now it's updated to use
`.workflows/docs.py` script instead of the old Bash script (which was
removed some time ago).

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
