### PR TITLE
Configure `core.editor` for each repository

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ if you `acquire-repository`, it proposes defaults that are set by `acquire-git`.
 
 1. setting your full name usign `user.name` [`b`]
 2. setting your email usign `user.email` [`b`]
-3. setting a default editor using `core.editor` [`i`]
+3. setting a default editor using `core.editor` [`b`]
 4. setting protected branches using `elegant-git.protected-branches` [`b`]
 
 # Level: Standards

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -32,18 +32,13 @@ MESSAGE
 default() {
     source ${BINS}/plugins/configuration
     source ${BINS}/plugins/configuration-protected-branches
-    if $(is-acquired) ; then
-        basics-configuration --local \
-            user_name \
-            user_email \
-            protected_branches
-        aliases-removing --local
-    else
-        basics-configuration --local \
+    aliases-removing --local
+    basics-configuration --local \
             user_name \
             user_email \
             core_editor \
             protected_branches
+    if ! is-acquired ; then
         standards-configuration --local \
             core_comment \
             apply_whitespace \
@@ -53,7 +48,6 @@ default() {
             core_autocrlf_windows pull_rebase \
             rebase_autoStash \
             credential_helper_darwin
-        aliases-removing --local
         aliases-configuration --local $(git elegant show-commands)
     fi
     type -p gpg >/dev/null 2>&1 || return 0

--- a/libexec/plugins/configuration
+++ b/libexec/plugins/configuration
@@ -10,7 +10,7 @@ user_email_message="What is your user email?"
 
 core_editor_key="core.editor"
 core_editor_default=$(git config "${core_editor_key}" || echo "vim")
-core_editor_message="Please specify a command to start the editor."
+core_editor_message="What is the command to launching an editor?"
 
 
 # mandatory

--- a/tests/git-elegant-acquire-git.bats
+++ b/tests/git-elegant-acquire-git.bats
@@ -28,7 +28,7 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --global user.name Elegant Git" ]]
     [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ ${lines[@]} =~ "==>> git config --global user.email elegant-git@example.com" ]]
-    [[ ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --global core.editor vi" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)?" ]]
     [[ ${lines[@]} =~ "==>> git config --global elegant-git.protected-branches master" ]]

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -27,7 +27,7 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --local user.name Elegant Git" ]]
     [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local user.email elegant-git@example.com" ]]
-    [[ ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local core.editor vi" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)? {master}:" ]]
     [[ ${lines[@]} =~ "==>> git config --local elegant-git.protected-branches master" ]]
@@ -43,7 +43,7 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --local user.name The User" ]]
     [[ ${lines[@]} =~ "What is your user email? {elegant-git@example.com}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local user.email the@email" ]]
-    [[ ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
+    [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local core.editor someeditor" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)? {master}:" ]]
     [[ ${lines[@]} =~ "==>> git config --local elegant-git.protected-branches a b" ]]
@@ -111,11 +111,12 @@ teardown() {
     [[ ${lines[@]} =~ "2 Elegant Git aliases were removed." ]]
 }
 
-@test "'acquire-repository': 'elegant.acquired' affects configuration correctly" {
+@test "'acquire-repository': works properly if 'elegant.acquired' == true " {
     fake-pass "uname -s" Linux
     repo git config --local "alias.aaa" "\"elegant aaa\""
     repo git config --global "alias.bbb" "\"elegant bbb\""
     repo git config --global "elegant.acquired" "true"
+    repo git config --local core.editor my-text-editor
     check git-elegant acquire-repository
     [[ ${lines[@]} =~ "What is your user name? {Elegant Git}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local user.name Elegant Git" ]]
@@ -123,8 +124,8 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --local user.email elegant-git@example.com" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)? {master}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local elegant-git.protected-branches master" ]]
-    [[ ! ${lines[@]} =~ "Please specify a command to start the editor. {vi}: " ]]
-    [[ ! ${lines[@]} =~ "==>> git config --local core.editor vi" ]]
+    [[ ${lines[@]} =~ "What is the command to launching an editor? {my-text-editor}: " ]]
+    [[ ${lines[@]} =~ "==>> git config --local core.editor my-text-editor" ]]
     [[ ! ${lines[@]} =~ "==>> git config --local core.commentChar |" ]]
     [[ ${lines[@]} =~ "1 Elegant Git aliases were removed." ]]
     [[ ! ${lines[@]} =~ "==>> git config --local alias.acquire-repository elegant acquire-repository" ]]


### PR DESCRIPTION
A user may want to have different editors for different repositories.
That's why now `acquire-repository` requires configuring a command for
launching the editor during the repository configuration.

Also, now the question is used to ask for a value of `core.editor` option
instead of just a statement.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
