### PR TITLE
Introduce Elegant Git badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [bl]: https://github.com/bees-hive/elegant-git/actions?workflow=Quality+pipeline
 [db]: https://readthedocs.org/projects/elegant-git/badge/?version=latest
 [dl]: https://elegant-git.bees-hive.org/en/latest/?badge=latest
+[eb]: https://img.shields.io/badge/assistant-Elegant%20Git-000000.svg
+[el]: https://github.com/bees-hive/elegant-git
 
 # Elegant Git
 Elegant Git is an assistant who carefully automates routine work with Git.
@@ -28,7 +30,8 @@ click on the picture :point_down::point_down::point_down: to see a demo.
 
 [![][sb]][sl] [![][ab]][al]
 
-[![][bb]][bl] [![][db]][dl] [![][0b]][0l]
+[![][bb]][bl] [![][db]][dl] [![][0b]][0l] [![][eb]][el]
+
 
 ---
 

--- a/docs/show-your-assistant.md
+++ b/docs/show-your-assistant.md
@@ -1,0 +1,25 @@
+# Show your assistant
+
+If you use Elegant Git - it means that you have a great assistant for your daily routine. And you
+can say about it by including a badge to your README file. It looks like this:
+
+[![git assistant: Elegant Git](https://img.shields.io/badge/assistant-Elegant%20Git-000000.svg)](https://github.com/bees-hive/elegant-git)
+
+Add the following line to project’s README.md:
+
+```md
+
+[![assistant: Elegant Git](https://img.shields.io/badge/assistant-Elegant%20Git-000000.svg)](https://github.com/bees-hive/elegant-git)
+
+```
+
+Add the following line to project’s README.rst:
+
+```rst
+
+.. image:: https://img.shields.io/badge/assistant-Elegant%20Git-000000.svg
+    :target: https://github.com/bees-hive/elegant-git
+
+```
+
+You are awesome!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - Getting started: getting-started.md
   - Configuration: configuration.md
   - Commands: commands.md
+  - Show your assistant: show-your-assistant.md
   - Release notes: https://github.com/bees-hive/elegant-git/releases
   - License: licence.md
 


### PR DESCRIPTION
A user may mention that Elegant Git is used for a project by adding a
badge into the project's README file. And, in order to unify the badge
and simplify the adding, the "Show your assistant" page is added. It
provides copy/paste badge for .md and .rst files.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
