### PR TITLE
Don't set protected branches in global configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ if you `acquire-repository`, it proposes defaults that are set by `acquire-git`.
 1. setting your full name usign `user.name` [`b`]
 2. setting your email usign `user.email` [`b`]
 3. setting a default editor using `core.editor` [`b`]
-4. setting protected branches using `elegant-git.protected-branches` [`b`]
+4. setting protected branches using `elegant-git.protected-branches` [`l`]
 
 # Level: Standards
 

--- a/libexec/git-elegant-acquire-git
+++ b/libexec/git-elegant-acquire-git
@@ -79,8 +79,7 @@ MESSAGE
     basics-configuration --global -- \
         user_name \
         user_email \
-        core_editor \
-        protected_branches
+        core_editor
     standards-configuration --global \
         core_comment \
         apply_whitespace \

--- a/tests/git-elegant-acquire-git.bats
+++ b/tests/git-elegant-acquire-git.bats
@@ -30,8 +30,8 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --global user.email elegant-git@example.com" ]]
     [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --global core.editor vi" ]]
-    [[ ${lines[@]} =~ "What are protected branches (split with space)?" ]]
-    [[ ${lines[@]} =~ "==>> git config --global elegant-git.protected-branches master" ]]
+    [[ ! ${lines[@]} =~ "What are protected branches (split with space)?" ]]
+    [[ ! ${lines[@]} =~ "==>> git config --global elegant-git.protected-branches master" ]]
 }
 
 @test "'acquire-git': standards are configured as expected on Windows" {

--- a/workflows
+++ b/workflows
@@ -34,7 +34,6 @@ repository() {
         git config --global user.name \"Elegant Git\"
         git config --global user.email elegant.git@email.com
         git config --global core.editor vi
-        git config --global elegant-git.protected-branches master
         git config --global elegant-git.acquired true
         ./install.bash /usr/local src
     "


### PR DESCRIPTION
By default, the `master` branch is protected even if the protected
branches were not configured. So, if a user doesn't run any
configuration, the `master` branch will be protected. If a user wants
to protect some other branch in the current (some) repository, then the
`acquire-repository` has to be executed - sets the protected branches.
So, there is no sense to configure protected branches during the global
configuration (`acquire-git`).

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
