### PR TITLE
Make the default development branch configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ if you `acquire-repository`, it proposes defaults that are set by `acquire-git`.
 2. setting your email usign `user.email` [`b`]
 3. setting a default editor using `core.editor` [`b`]
 4. setting protected branches using `elegant-git.protected-branches` [`l`]
+5. setting a default development branch using `elegant-git.default-branch` [`l`]
 
 # Level: Standards
 
@@ -84,9 +85,14 @@ For now, only `gpg` is supported. If you need other tools, please [create a new 
 The Elegant Git configuration keys:
 
 - `elegant-git.protected-branches` defines the protected branches (if there are multiple values, they
-should be separarated with space). By default, `master` branch treats as protected. The "protected"
+should be separarated with space). By default, the `master` branch treats as protected. The "protected"
 means that Elegant Git commands for a branch state modification (such as `save-work`, `polish-work`,
 etc.) are prohibited to work if the current branch is protected. Also, the protected branches cannot
 be removed while running Elegant Git commands for serving a repository.
 - `elegant-git.acquired` defines whether a user was applied global configuration or not (see
 [approach](#approach) for the details).
+- `elegant-git.default-branch` defines the name of the default development branch. By default, the `master`
+branch treats as the default one. Depending on an Elegant Git command, it can be a source branch to create
+a new branch from, a destination branch to rebase work in, a base branch to compare with, a release branch,
+and can be used in other ways. In other words, the default development branch is "a golden source" of
+modifications (commits) for any manipulation that needs them.

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -28,10 +28,6 @@ git-verbose-op() {
     ${processor} "$(git "$@" 2>&1)"
 }
 
-DEFAULT_BRANCH="master"
-DEFAULT_UPSTREAM_REPOSITORY="origin"
-DEFAULT_REMOTE_TRACKING_BRANCH="${DEFAULT_UPSTREAM_REPOSITORY}/${DEFAULT_BRANCH}"
-
 _error-if-empty() {
     # _error-if-empty <a value to check> <error message>
     if [[ -z "$1" ]]; then

--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -60,6 +60,7 @@ MESSAGE
     local work_branch="__eg"
     local changes=${1}
     source ${BINS}/plugins/state
+    source ${BINS}/plugins/configuration-default-branches
     if is-there-active-rebase; then
         local rb=$(rebasing-branch)
         if [[ ${work_branch} == ${rb} ]]; then

--- a/libexec/git-elegant-acquire-repository
+++ b/libexec/git-elegant-acquire-repository
@@ -32,12 +32,14 @@ MESSAGE
 default() {
     source ${BINS}/plugins/configuration
     source ${BINS}/plugins/configuration-protected-branches
+    source ${BINS}/plugins/configuration-default-branches
     source ${BINS}/plugins/configuration-acquired
     obsolete-configurations-removing --local
     basics-configuration --local \
             user_name \
             user_email \
             core_editor \
+            default_branch \
             protected_branches
     if ! is-git-acquired ; then
         standards-configuration --local \

--- a/libexec/git-elegant-deliver-work
+++ b/libexec/git-elegant-deliver-work
@@ -58,6 +58,7 @@ MESSAGE
 --deliver-work-logic() {
     source ${BINS}/plugins/state
     source ${BINS}/plugins/transformation
+    source ${BINS}/plugins/configuration-default-branches
     if is-there-active-rebase; then
         git-verbose rebase --continue
     else

--- a/libexec/git-elegant-polish-work
+++ b/libexec/git-elegant-polish-work
@@ -39,6 +39,7 @@ MESSAGE
 default() {
     local current_branch=$(git rev-parse --abbrev-ref HEAD)
     source ${BINS}/plugins/configuration-protected-branches
+    source ${BINS}/plugins/configuration-default-branches
     if is-branch-protected ${current_branch}; then
         error-box "The protected '${current_branch}' branch history can't be rewritten."
         error-text "Please read more on ${__site}."

--- a/libexec/git-elegant-prune-repository
+++ b/libexec/git-elegant-prune-repository
@@ -43,6 +43,7 @@ MESSAGE
 
 default() {
     source ${BINS}/plugins/state
+    source ${BINS}/plugins/configuration-default-branches
     git-verbose checkout ${DEFAULT_BRANCH}
     if is-there-upstream-for ${DEFAULT_BRANCH}; then
         git-verbose fetch --all || info-text "As the remotes can't be fetched, the current local version is used."

--- a/libexec/git-elegant-release-work
+++ b/libexec/git-elegant-release-work
@@ -59,6 +59,7 @@ MESSAGE
 }
 
 --release-work() {
+    source ${BINS}/plugins/configuration-default-branches
     git-verbose checkout ${DEFAULT_BRANCH}
     git-verbose pull --tags
     source ${BINS}/plugins/state

--- a/libexec/git-elegant-show-work
+++ b/libexec/git-elegant-show-work
@@ -22,7 +22,7 @@ modifications, and available stashes.
 Approximate commands flow is
 \`\`\`bash
 ==>> git elegant show-work
-git log --oneline ${DEFAULT_BRANCH}..@
+git log --oneline master..@
 git status --short
 git stash list
 \`\`\`
@@ -30,6 +30,7 @@ MESSAGE
 }
 
 default(){
+    source ${BINS}/plugins/configuration-default-branches
     local branch=$(git rev-parse --abbrev-ref @)
     info-text ">>> Branch refs:"
     info-text "local:  ${branch}"

--- a/libexec/git-elegant-start-work
+++ b/libexec/git-elegant-start-work
@@ -43,6 +43,7 @@ MESSAGE
 
 --start-work-logic(){
     source ${BINS}/plugins/state
+    source ${BINS}/plugins/configuration-default-branches
     local target=${2:-${DEFAULT_BRANCH}}
     git-verbose checkout ${target}
     if is-there-upstream-for ${target}; then

--- a/libexec/plugins/configuration-default-branches
+++ b/libexec/plugins/configuration-default-branches
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# This plugin is responsible for handling default branches logic.
+default_branch_key="elegant-git.default-branch"
+default_branch_default="master"
+default_branch_message="What is the default branch?"
+
+DEFAULT_BRANCH=$(git config ${default_branch_key} || echo ${default_branch_default})
+DEFAULT_UPSTREAM_REPOSITORY="origin"
+DEFAULT_REMOTE_TRACKING_BRANCH="${DEFAULT_UPSTREAM_REPOSITORY}/${DEFAULT_BRANCH}"

--- a/tests/git-elegant-acquire-repository.bats
+++ b/tests/git-elegant-acquire-repository.bats
@@ -29,6 +29,8 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --local user.email elegant-git@example.com" ]]
     [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local core.editor vi" ]]
+    [[ ${lines[@]} =~ "What is the default branch? {master}:" ]]
+    [[ ${lines[@]} =~ "==>> git config --local elegant-git.default-branch master" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)? {master}:" ]]
     [[ ${lines[@]} =~ "==>> git config --local elegant-git.protected-branches master" ]]
 }
@@ -37,6 +39,7 @@ teardown() {
     read-answer "The User"
     read-answer "the@email"
     read-answer "someeditor"
+    read-answer "my-branch"
     read-answer "a b"
     check git-elegant acquire-repository
     [[ ${lines[@]} =~ "What is your user name? {Elegant Git}: " ]]
@@ -45,6 +48,8 @@ teardown() {
     [[ ${lines[@]} =~ "==>> git config --local user.email the@email" ]]
     [[ ${lines[@]} =~ "What is the command to launching an editor? {vi}: " ]]
     [[ ${lines[@]} =~ "==>> git config --local core.editor someeditor" ]]
+    [[ ${lines[@]} =~ "What is the default branch? {master}:" ]]
+    [[ ${lines[@]} =~ "==>> git config --local elegant-git.default-branch my-branch" ]]
     [[ ${lines[@]} =~ "What are protected branches (split with space)? {master}:" ]]
     [[ ${lines[@]} =~ "==>> git config --local elegant-git.protected-branches a b" ]]
 }
@@ -135,6 +140,7 @@ teardown() {
     read-answer "The User"
     read-answer "the@email"
     read-answer "someeditor"
+    read-answer "master"
     read-answer "master"
     read-answer "thekey"
     fake-pass "gpg --list-secret-keys --keyid-format long the@email" "some dummy keys"


### PR DESCRIPTION
Up to now, the `master` branch was the default development branch. And
now it's possible to configure it by running the `acquire-repository`
command. So, after the configuration, the provided value will be used
instead of the `master`. However, the `master` is still a default one.
But now, it's possible to set another branch as a default one (for
instance, `develop`) and Elegant Git will use it.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
