### PR TITLE
Allow `./workflows robot` to run updated `.bats` files

### DIFF
--- a/workflows
+++ b/workflows
@@ -134,7 +134,7 @@ robot() {
         if [[ ${command_files[@]} =~ "${file_name/.bats/}" ]] ; then
             continue # already tested
         fi
-        if ! test -f tests/${command_name}.bats; then continue; fi
+        if ! test -f tests/${file_name}; then continue; fi
         ( testing ${file_name} && info-text "'${file_name}' testing is passed.") || {
             error-text "'${file_name}' testing is failed."
             smart_testing_status=failed


### PR DESCRIPTION
There is an error in the `robot` command algorithm that doesn't run Bats
tests if they were changed. It happens as the wrong variable was used to
identify whether a test file exists or not.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
