### PR TITLE
Display only the last installed version of Elegant Git

### DIFF
--- a/.workflows/bats/bats-workflows.bash
+++ b/.workflows/bats/bats-workflows.bash
@@ -2,9 +2,6 @@
 set -e
 # Runs bats tests
 # usage: ./script [command name]
-if [[ -f version ]]; then
-    rm -v version
-fi
 
 all_tests() {
     exec bats --tap --recursive tests

--- a/install.bash
+++ b/install.bash
@@ -91,7 +91,7 @@ TEXT
 
 add-version() {
     cd "${1}"
-    git describe >> version
+    git describe > version
     cd -
 }
 

--- a/tests/git-elegant.bats
+++ b/tests/git-elegant.bats
@@ -43,7 +43,13 @@ teardown(){
 
 @test "'git elegant': a version is displayed correctly" {
     check git-elegant --version
-    [[ ${lines[@]} =~ "/elegant-git/tests/../libexec/../version" ]]
+    if test -f ${THIS}/../version; then
+        [[ ${status} -eq 0 ]]
+        [[ ${#lines[*]} -eq 1 ]]
+    else
+        [[ ${status} -ne 0 ]]
+        [[ ${lines[@]} =~ "tests/../libexec/../version" ]]
+    fi
 }
 
 @test "'git elegant': workflows are loaded correctly when a command is executed from root directory" {


### PR DESCRIPTION
If the installation process is repeated several times from the same
cloned source directory, `install.bash` will append a version to
the `version` file after each installation. This is unacceptable
behavior as the installed package always should display only one
relevant version.

In order to solve this behavior, several updates took place:
1. `install.bash` always rewrites the `version` file instead of
   appending it
2. a Bats test that checks `git-elegant --version` logic can work
   independently from the presence or absence of the `version` file. So,
   if there is no file, it checks a correctness of the `version` file
   location. Otherwise, it checks if there is only one version line.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
