### PR TITLE
Pass `git clone` arguments to `git-elegant clone-repository`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,19 +155,19 @@ git commit --amend
 # `clone-repository`
 
 ```bash
-usage: git elegant clone-repository <repository>
+usage: git elegant clone-repository [options] <repository> [<directory>]
 ```
 
 Clones a repository into a new directory and runs its configuration.
 
-A `<repository>` is an Git URL to the repository to clone from (see
-`git clone --help` for the details).
+The command accepts everything that `git clone` command accepts.
+Run `git clone --help` to see the available options.
 
 Approximate commands flow is
 ```bash
-==>> git elegant clone-repository git@github.com:bees-hive/elegant-git.git
-git clone git@github.com:bees-hive/elegant-git.git
-cd elegant-git
+==>> git elegant clone-repository --depth 5 git@github.com:bees-hive/elegant-git.git my-dir
+git clone --depth 5 git@github.com:bees-hive/elegant-git.git my-dir
+cd my-dir
 git elegant acquire-repository
 ```
 

--- a/libexec/git-elegant-clone-repository
+++ b/libexec/git-elegant-clone-repository
@@ -9,7 +9,7 @@ MESSAGE
 
 command-synopsis() {
     cat <<MESSAGE
-usage: git elegant clone-repository <repository>
+usage: git elegant clone-repository [options] <repository> [<directory>]
 MESSAGE
 }
 
@@ -17,22 +17,29 @@ command-description() {
     cat<<MESSAGE
 Clones a repository into a new directory and runs its configuration.
 
-A \`<repository>\` is an Git URL to the repository to clone from (see
-\`git clone --help\` for the details).
+The command accepts everything that \`git clone\` command accepts.
+Run \`git clone --help\` to see the available options.
 
 Approximate commands flow is
 \`\`\`bash
-==>> git elegant clone-repository git@github.com:bees-hive/elegant-git.git
-git clone git@github.com:bees-hive/elegant-git.git
-cd elegant-git
+==>> git elegant clone-repository --depth 5 git@github.com:bees-hive/elegant-git.git my-dir
+git clone --depth 5 git@github.com:bees-hive/elegant-git.git my-dir
+cd my-dir
 git elegant acquire-repository
 \`\`\`
 MESSAGE
 }
 
 default() {
-    _error-if-empty "$1" "Cloneable URL is not set."
-    git-verbose clone "$1"
-    cd $(basename -s .git $1)
+    _error-if-empty "${1}" "There are no arguments!"
+    for location in "${@}"; do :; done
+    if [[ "${location}" =~ (.git$) ]]; then
+        # remove all prior last slash inclusively
+        location=${location##*/}
+        # remove '.git' in the end
+        location=${location//.git}
+    fi
+    info-text "The repository was cloned into '${location}' directory."
+    cd "${location}"
     git elegant acquire-repository
 }

--- a/tests/git-elegant-clone-repository.bats
+++ b/tests/git-elegant-clone-repository.bats
@@ -1,15 +1,11 @@
-#!/usr/bin/env bats -ex
+#!/usr/bin/env bats
 
 load addons-common
-load addons-read
 load addons-cd
 load addons-fake
 
 setup() {
-    fake-pass "git clone-repository"
-    fake-pass "git clone https://github.com/extsoft/elegant-git.git"
     fake-pass "git elegant acquire-repository"
-    fake-pass "git rev-parse --show-cdup"
 }
 
 teardown() {
@@ -19,10 +15,33 @@ teardown() {
 @test "'clone-repository': stops with exit code 45 if cloneable URL is not set" {
     check git-elegant clone-repository
     [[ ${status} -eq 45 ]]
-    [[ ${lines[0]} =~ "Cloneable URL is not set" ]]
+    [[ ${lines[0]} =~ "There are no arguments!" ]]
 }
 
-@test "'clone-repository': clone the repo" {
+@test "'clone-repository': clone given repository and store to the default directory" {
+    fake-pass "git clone https://github.com/extsoft/elegant-git.git"
     check git-elegant clone-repository https://github.com/extsoft/elegant-git.git
     [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "The repository was cloned into 'elegant-git' directory." ]]
+}
+
+@test "'clone-repository': clone given repository and store to the given directory" {
+    fake-pass "git clone https://github.com/extsoft/elegant-git.git my-elegnat-git"
+    check git-elegant clone-repository https://github.com/extsoft/elegant-git.git my-elegnat-git
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "The repository was cloned into 'my-elegnat-git' directory." ]]
+}
+
+@test "'clone-repository': clone given repository with specific options" {
+    fake-pass "git clone --branch work1 https://github.com/extsoft/elegant-git.git"
+    check git-elegant clone-repository --branch work1 https://github.com/extsoft/elegant-git.git
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "The repository was cloned into 'elegant-git' directory." ]]
+}
+
+@test "'clone-repository': clone given repository with specific options and store to the given directory" {
+    fake-pass "git clone --branch work1 https://github.com/extsoft/elegant-git.git work1"
+    check git-elegant clone-repository --branch work1 https://github.com/extsoft/elegant-git.git work1
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "The repository was cloned into 'work1' directory." ]]
 }


### PR DESCRIPTION
Sometimes you may need to pass specific options when cloning a
repository. And now you can pass any options `git clone` support as the
arguments to `clone-repository` command.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
