### PR TITLE
Restore line with `git clone` in `clone-repository` command

### DIFF
--- a/libexec/git-elegant-clone-repository
+++ b/libexec/git-elegant-clone-repository
@@ -32,6 +32,7 @@ MESSAGE
 
 default() {
     _error-if-empty "${1}" "There are no arguments!"
+    git-verbose clone "${@}"
     for location in "${@}"; do :; done
     if [[ "${location}" =~ (.git$) ]]; then
         # remove all prior last slash inclusively

--- a/tests/git-elegant-clone-repository.bats
+++ b/tests/git-elegant-clone-repository.bats
@@ -22,6 +22,7 @@ teardown() {
     fake-pass "git clone https://github.com/extsoft/elegant-git.git"
     check git-elegant clone-repository https://github.com/extsoft/elegant-git.git
     [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git clone https://github.com/extsoft/elegant-git.git" ]]
     [[ ${lines[*]} =~ "The repository was cloned into 'elegant-git' directory." ]]
 }
 
@@ -29,6 +30,7 @@ teardown() {
     fake-pass "git clone https://github.com/extsoft/elegant-git.git my-elegnat-git"
     check git-elegant clone-repository https://github.com/extsoft/elegant-git.git my-elegnat-git
     [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git clone https://github.com/extsoft/elegant-git.git my-elegnat-git" ]]
     [[ ${lines[*]} =~ "The repository was cloned into 'my-elegnat-git' directory." ]]
 }
 
@@ -36,6 +38,7 @@ teardown() {
     fake-pass "git clone --branch work1 https://github.com/extsoft/elegant-git.git"
     check git-elegant clone-repository --branch work1 https://github.com/extsoft/elegant-git.git
     [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git clone --branch work1 https://github.com/extsoft/elegant-git.git" ]]
     [[ ${lines[*]} =~ "The repository was cloned into 'elegant-git' directory." ]]
 }
 
@@ -43,5 +46,6 @@ teardown() {
     fake-pass "git clone --branch work1 https://github.com/extsoft/elegant-git.git work1"
     check git-elegant clone-repository --branch work1 https://github.com/extsoft/elegant-git.git work1
     [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git clone --branch work1 https://github.com/extsoft/elegant-git.git work1" ]]
     [[ ${lines[*]} =~ "The repository was cloned into 'work1' directory." ]]
 }


### PR DESCRIPTION
This line was occasionally removed from the command. But it should be
present.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
