### PR TITLE
Add `actualize-work` command

### DIFF
--- a/completions/_git-elegant
+++ b/completions/_git-elegant
@@ -14,6 +14,7 @@ _git-elegant (){
         'accept-work:adds modifications to the default development branch'
         'acquire-git:configures your Git installation'
         'acquire-repository:configures the current local Git repository'
+        'actualize-work:actualizes the current branch with upstream commits'
         'amend-work:amends the last commit'
         'clone-repository:clones a remote repository and configures it'
         'deliver-work:publishes HEAD to a remote repository'
@@ -64,7 +65,7 @@ __ge_complete_commands () {
     # default completion is empty
     case ${line[1]} in
         obtain-work)                __ge_remotes ;;
-        accept-work)                __ge_all_branches ;;
+        accept-work|actualize-work) __ge_all_branches ;;
         show-release-notes)         __ge_show_release_notes ;;
         start-work)                 __ge_start_work ;;
         make-workflow)              __ge_make_workflow ;;

--- a/completions/git-elegant.bash
+++ b/completions/git-elegant.bash
@@ -32,7 +32,7 @@ _git_elegant() {
                     $(compgen -W "${opts[*]}" -- ${cursor})
                 )
                 ;;
-            accept-work)
+            accept-work|actualize-work)
                 local opts=(
                     ${gecops}
                     $(git branch --all --format='%(refname:short)')

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,7 @@ There are commands used in various situations such as
     amend-work           Amends the last commit.
     show-work            Prints HEAD state.
     polish-work          Rebases HEAD interactively.
+    actualize-work       Actualizes the current branch with upstream commits.
 
  interact with others
     deliver-work         Publishes HEAD to a remote repository.
@@ -131,6 +132,34 @@ applies all configurations to the current local repository.
 
 To find out what will be configured, please visit
 <https://elegant-git.bees-hive.org/en/latest/configuration/>
+
+# `actualize-work`
+
+```bash
+usage: git elegant actualize-work [branch-name]
+```
+
+Rebases the head of the upstream branch into the current one. By default, the
+upstream branch is the default development branch.
+
+A `[branch-name]` argument allows you to redefine the upstream branch. It
+supports both local and remote branches.
+
+If the upstream branch has a remote-tracking branch or is a remote branch, it
+fetches before making a rebase.
+
+If there is a rebase in progress initiated by this command, it will be
+continued prior to running the main logic.
+
+The command uses stash pipe to preserve the current Git state prior to execution
+and restore after.
+
+Approximate commands flow is
+```bash
+==>> git elegant actualize-work origin/some-work
+git fetch
+git rebase origin/some-work
+```
 
 # `amend-work`
 

--- a/libexec/git-elegant
+++ b/libexec/git-elegant
@@ -82,6 +82,7 @@ $(--print-command-in-usage save-work)
 $(--print-command-in-usage amend-work)
 $(--print-command-in-usage show-work)
 $(--print-command-in-usage polish-work)
+$(--print-command-in-usage actualize-work)
 
  interact with others
 $(--print-command-in-usage deliver-work)

--- a/libexec/git-elegant-actualize-work
+++ b/libexec/git-elegant-actualize-work
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+command-purpose() {
+    cat <<MESSAGE
+Actualizes the current branch with upstream commits.
+MESSAGE
+}
+
+command-synopsis() {
+    cat <<MESSAGE
+usage: git elegant actualize-work [branch-name]
+MESSAGE
+}
+
+command-description() {
+    cat<<MESSAGE
+Rebases the head of the upstream branch into the current one. By default, the
+upstream branch is the default development branch.
+
+A \`[branch-name]\` argument allows you to redefine the upstream branch. It
+supports both local and remote branches.
+
+If the upstream branch has a remote-tracking branch or is a remote branch, it
+fetches before making a rebase.
+
+If there is a rebase in progress initiated by this command, it will be
+continued prior to running the main logic.
+
+The command uses stash pipe to preserve the current Git state prior to execution
+and restore after.
+
+Approximate commands flow is
+\`\`\`bash
+==>> git elegant actualize-work origin/some-work
+git fetch
+git rebase origin/some-work
+\`\`\`
+MESSAGE
+}
+
+--fetch() {
+    git-verbose fetch || info-text "Unable to fetch. The last local revision will be used."
+}
+
+--logic() {
+    source ${BINS}/plugins/state
+    if is-there-active-rebase
+    then
+        git-verbose rebase --continue
+    fi
+    source ${BINS}/plugins/configuration-default-branches
+    source ${BINS}/plugins/state
+    if test -n "${1}"
+    then
+        if is-remote-branch ${1}
+        then
+            --fetch
+            git-verbose rebase ${1}
+        elif is-there-upstream-for ${1}
+        then
+            --fetch
+            git-verbose rebase $(upstream-of ${1}) ${1}
+            git-verbose rebase ${1}
+        else
+            git-verbose rebase ${1}
+        fi
+    elif are-there-remotes
+    then
+        --fetch
+        git-verbose rebase ${DEFAULT_REMOTE_TRACKING_BRANCH}
+    else
+        git-verbose rebase ${DEFAULT_BRANCH}
+    fi
+}
+
+default() {
+    stash-pipe --logic "${@}"
+}

--- a/libexec/plugins/state
+++ b/libexec/plugins/state
@@ -34,6 +34,16 @@ is-there-upstream-for() {
     git rev-parse --abbrev-ref ${1}@{upstream} >/dev/null 2>&1
 }
 
+upstream-of() {
+    # usage: $(upstream-of <branch ref>)
+    git rev-parse --abbrev-ref ${1}@{upstream} 2>/dev/null || true
+}
+
+is-remote-branch() {
+    # usage: is-remote-branch <branch ref>
+    test -n "$(git for-each-ref refs/remotes/${1})"
+}
+
 are-there-remotes() {
     if test -z "$(git remote)"; then
         return 1

--- a/tests/git-elegant-actualize-work.bats
+++ b/tests/git-elegant-actualize-work.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+load addons-common
+load addons-fake
+load addons-repo
+
+setup() {
+    repo-new
+}
+
+teardown() {
+    repo-clean
+    fake-clean
+}
+
+@test "'actualize-work': makes a rebase of the default local branch if there is no remote repository" {
+    fake-pass "git rebase master"
+    check git-elegant actualize-work
+    [[ ${status} -eq 0 ]]
+    [[ ! ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "git rebase master" ]]
+}
+
+@test "'actualize-work': makes a rebase of the default remote branch if there is a remote repository" {
+    fake-pass "git remote" "origin"
+    fake-pass "git rebase origin/master"
+    fake-fail "git rebase master"
+    check git-elegant actualize-work
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "git rebase origin/master" ]]
+}
+
+@test "'actualize-work': uses local revision of the default remote branch if the fetch is failed" {
+    fake-pass "git remote" "origin"
+    fake-fail "git fetch"
+    fake-pass "git rebase origin/master"
+    fake-fail "git rebase master"
+    check git-elegant actualize-work
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "Unable to fetch. The last local revision will be used." ]]
+    [[ ${lines[*]} =~ "git rebase origin/master" ]]
+}
+
+@test "'actualize-work': makes a rebase of the given local branch without remote-tracking branch" {
+    fake-pass "git rebase branch"
+    check git-elegant actualize-work branch
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git rebase branch" ]]
+    [[ ! ${lines[*]} =~ "git fetch" ]]
+}
+
+@test "'actualize-work': makes a rebase of the given local branch with remote-tracking branch" {
+    fake-pass "git rev-parse --abbrev-ref rt@{upstream}"
+    fake-pass "git fetch"
+    fake-pass "git rev-parse --abbrev-ref rt@{upstream}" "origin/rt"
+    fake-pass "git rebase origin/rt rt"
+    fake-pass "git rebase rt"
+    check git-elegant actualize-work rt
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "git rebase origin/rt rt" ]]
+    [[ ${lines[*]} =~ "git rebase rt" ]]
+}
+
+@test "'actualize-work': makes a rebase of the given remote-tracking branch" {
+    fake-pass "git for-each-ref refs/remotes/only/remote" "true"
+    fake-pass "git fetch"
+    fake-pass "git rebase only/remote"
+    check git-elegant actualize-work only/remote
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "git rebase only/remote" ]]
+}
+
+@test "'actualize-work': uses local revision of thegiven remote-tracking branch if the fetch is failed" {
+    fake-pass "git rev-parse --abbrev-ref rt@{upstream}"
+    fake-fail "git fetch"
+    fake-pass "git rev-parse --abbrev-ref rt@{upstream}" "origin/rt"
+    fake-pass "git rebase origin/rt rt"
+    fake-pass "git rebase rt"
+    check git-elegant actualize-work rt
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "Unable to fetch. The last local revision will be used." ]]
+    [[ ${lines[*]} =~ "git rebase origin/rt rt" ]]
+    [[ ${lines[*]} =~ "git rebase rt" ]]
+}
+
+@test "'actualize-work': uses stash pipe if uncommited changes are present" {
+    repo-non-staged-change "A new line..."
+    check git-elegant actualize-work
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git stash push --message git-elegant actualize-work auto-stash:" ]]
+    [[ ! ${lines[*]} =~ "git fetch" ]]
+    [[ ${lines[*]} =~ "git rebase master" ]]
+    [[ ${lines[@]} =~ "git stash pop" ]]
+}
+
+@test "'actualize-work': continues an existing rebase process there is an active rebase process" {
+    repo "git checkout -b feature1"
+    repo "git commit --allow-empty --message First"
+    repo "git commit --allow-empty --message Second"
+    repo "git rebase --exec 'grep bla-bla *.txt' @~1 || true "
+    check git-elegant actualize-work
+    [[ ${status} -eq 0 ]]
+    [[ ${lines[@]} =~ "git rebase --continue" ]]
+    [[ ${lines[@]} =~ "git rebase master" ]]
+}

--- a/tests/git-elegant-show-commands.bats
+++ b/tests/git-elegant-show-commands.bats
@@ -32,6 +32,7 @@ teardown() {
         "show-workflows"
         "make-workflow"
         "polish-workflow"
+        "actualize-work"
     )
     check git-elegant show-commands
     [[ ${#lines[@]} -eq ${#COMMANDS[@]} ]]


### PR DESCRIPTION
The command aims to simplify work with obsolete branches as it provides
a convenient way to actualize them.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
