### PR TITLE
Actualize work based on what a user requests

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,8 +145,8 @@ upstream branch is the default development branch.
 A `[branch-name]` argument allows you to redefine the upstream branch. It
 supports both local and remote branches.
 
-If the upstream branch has a remote-tracking branch or is a remote branch, it
-fetches before making a rebase.
+If the upstream branch is a remote branch, a fetch is invoked before making
+a rebase in order to get the latest changes.
 
 If there is a rebase in progress initiated by this command, it will be
 continued prior to running the main logic.

--- a/libexec/git-elegant-actualize-work
+++ b/libexec/git-elegant-actualize-work
@@ -21,8 +21,8 @@ upstream branch is the default development branch.
 A \`[branch-name]\` argument allows you to redefine the upstream branch. It
 supports both local and remote branches.
 
-If the upstream branch has a remote-tracking branch or is a remote branch, it
-fetches before making a rebase.
+If the upstream branch is a remote branch, a fetch is invoked before making
+a rebase in order to get the latest changes.
 
 If there is a rebase in progress initiated by this command, it will be
 continued prior to running the main logic.
@@ -56,11 +56,6 @@ MESSAGE
         if is-remote-branch ${1}
         then
             --fetch
-            git-verbose rebase ${1}
-        elif is-there-upstream-for ${1}
-        then
-            --fetch
-            git-verbose rebase $(upstream-of ${1}) ${1}
             git-verbose rebase ${1}
         else
             git-verbose rebase ${1}

--- a/tests/git-elegant-actualize-work.bats
+++ b/tests/git-elegant-actualize-work.bats
@@ -43,7 +43,7 @@ teardown() {
     [[ ${lines[*]} =~ "git rebase origin/master" ]]
 }
 
-@test "'actualize-work': makes a rebase of the given local branch without remote-tracking branch" {
+@test "'actualize-work': makes a rebase of the given local branch" {
     fake-pass "git rebase branch"
     check git-elegant actualize-work branch
     [[ ${status} -eq 0 ]]
@@ -51,18 +51,6 @@ teardown() {
     [[ ! ${lines[*]} =~ "git fetch" ]]
 }
 
-@test "'actualize-work': makes a rebase of the given local branch with remote-tracking branch" {
-    fake-pass "git rev-parse --abbrev-ref rt@{upstream}"
-    fake-pass "git fetch"
-    fake-pass "git rev-parse --abbrev-ref rt@{upstream}" "origin/rt"
-    fake-pass "git rebase origin/rt rt"
-    fake-pass "git rebase rt"
-    check git-elegant actualize-work rt
-    [[ ${status} -eq 0 ]]
-    [[ ${lines[*]} =~ "git fetch" ]]
-    [[ ${lines[*]} =~ "git rebase origin/rt rt" ]]
-    [[ ${lines[*]} =~ "git rebase rt" ]]
-}
 
 @test "'actualize-work': makes a rebase of the given remote-tracking branch" {
     fake-pass "git for-each-ref refs/remotes/only/remote" "true"
@@ -74,18 +62,15 @@ teardown() {
     [[ ${lines[*]} =~ "git rebase only/remote" ]]
 }
 
-@test "'actualize-work': uses local revision of thegiven remote-tracking branch if the fetch is failed" {
-    fake-pass "git rev-parse --abbrev-ref rt@{upstream}"
+@test "'actualize-work': uses local revision of the given remote-tracking branch if the fetch is failed" {
+    fake-pass "git for-each-ref refs/remotes/origin/rt" "true"
     fake-fail "git fetch"
-    fake-pass "git rev-parse --abbrev-ref rt@{upstream}" "origin/rt"
-    fake-pass "git rebase origin/rt rt"
-    fake-pass "git rebase rt"
-    check git-elegant actualize-work rt
+    fake-pass "git rebase origin/rt"
+    check git-elegant actualize-work origin/rt
     [[ ${status} -eq 0 ]]
     [[ ${lines[*]} =~ "git fetch" ]]
     [[ ${lines[*]} =~ "Unable to fetch. The last local revision will be used." ]]
-    [[ ${lines[*]} =~ "git rebase origin/rt rt" ]]
-    [[ ${lines[*]} =~ "git rebase rt" ]]
+    [[ ${lines[*]} =~ "git rebase origin/rt" ]]
 }
 
 @test "'actualize-work': uses stash pipe if uncommited changes are present" {


### PR DESCRIPTION
The logic of replacing a local branch with its remote-tracking one
confuses. This means that `git actualize-work feature-3` does a rebase
of `origin/feature-3` instead of `feature-3` branch.

This change removes such logic. And now, the rebase will use a given
branch or a default development one only.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
