### PR TITLE
Use the latest version of the default branch commits

### DIFF
--- a/libexec/git-elegant-accept-work
+++ b/libexec/git-elegant-accept-work
@@ -77,11 +77,7 @@ MESSAGE
         else
             git elegant obtain-work "${changes}" "${work_branch}"
         fi
-        if are-there-remotes; then
-            git-verbose rebase ${DEFAULT_REMOTE_TRACKING_BRANCH}
-        else
-            git-verbose rebase ${DEFAULT_BRANCH}
-        fi
+        git-verbose rebase $(freshest-default-branch)
     fi
     local actual_remote=$(git for-each-ref --format='%(upstream:short)' refs/heads/${work_branch})
     git-verbose checkout ${DEFAULT_BRANCH}

--- a/libexec/git-elegant-polish-work
+++ b/libexec/git-elegant-polish-work
@@ -49,9 +49,10 @@ default() {
     if is-there-active-rebase; then
         git-verbose rebase --continue
     else
-        local commits=($(git rev-list ${DEFAULT_BRANCH}..@))
+        local latest_changes=$(freshest-default-branch)
+        local commits=($(git rev-list ${latest_changes}..@))
         if [[ ${#commits[*]} -eq 0 ]]; then
-            info-text "There are no new commits comparing to '${DEFAULT_BRANCH}' branch."
+            info-text "There are no new commits comparing to '${latest_changes}' branch."
         else
             stash-pipe git-verbose rebase --interactive @~${#commits[*]}
         fi

--- a/libexec/git-elegant-show-work
+++ b/libexec/git-elegant-show-work
@@ -39,9 +39,10 @@ default(){
         info-text "remote: ${upstream}"
     fi
     info-text ""
-    if [[ -n $(git rev-list ${DEFAULT_BRANCH}..${branch}) ]]; then
-        info-text ">>> New commits (comparing to '${DEFAULT_BRANCH}' branch):"
-        git log --oneline ${DEFAULT_BRANCH}..${branch}
+    local latest_changes=$(freshest-default-branch)
+    if [[ -n $(git rev-list ${latest_changes}..${branch}) ]]; then
+        info-text ">>> New commits (comparing to '${latest_changes}' branch):"
+        git log --oneline ${latest_changes}..${branch}
         info-text ""
     fi
     if [[ -n $(git status --short) ]]; then

--- a/libexec/plugins/configuration-default-branches
+++ b/libexec/plugins/configuration-default-branches
@@ -7,3 +7,16 @@ default_branch_message="What is the default branch?"
 DEFAULT_BRANCH=$(git config ${default_branch_key} || echo ${default_branch_default})
 DEFAULT_UPSTREAM_REPOSITORY="origin"
 DEFAULT_REMOTE_TRACKING_BRANCH="${DEFAULT_UPSTREAM_REPOSITORY}/${DEFAULT_BRANCH}"
+
+freshest-default-branch() {
+    # If there is a remote, the remote branch will have the latest version of changes.
+    # Meanwhile, the local one can have non-fresh changes as `git fetch` doesn't update
+    # the local branch.
+    # usage: $(freshest-default-branch)
+    if test -z "$(git remote)"
+    then
+        echo ${DEFAULT_BRANCH}
+    else
+        echo ${DEFAULT_REMOTE_TRACKING_BRANCH}
+    fi
+}


### PR DESCRIPTION
There is a local repository that has an associated remote. If Elegant
Git is used for serving interactions with it, it may happen that
the default local branch won't have all commits that are presented in
the local remote branch. This happens because Elegant Git uses the
`fetch` operation to get the latest changes that update the local
remote branches, not the local branches. This leads to not up-to-date
outputs of commands such as `polish-work`, `show-work`, etc.

From the implementation side, the default branch (`master` or any other
configured) is used as the source of the latest commits. However,
`origin/master` can have more commits then `master`.

That's why `origin/master` is enforced to be used in such cases. This
guarantee that Elegant Git will use the latest available commits.

The contribution:
- [x] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
