### PR TITLE
Switch haskell project to new GHC verion

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -4,10 +4,10 @@ cradle:
       component: "elegant-git:lib"
 
     - path: "./app/Main.hs"
-      component: "elegant-git:exe:elegant-git-exe"
+      component: "elegant-git:exe:git-elegant"
 
     - path: "./app/Paths_elegant_git.hs"
-      component: "elegant-git:exe:elegant-git-exe"
+      component: "elegant-git:exe:git-elegant"
 
     - path: "./test"
       component: "elegant-git:test:elegant-git-test"

--- a/src/Elegit/Git/Runner/Real.hs
+++ b/src/Elegit/Git/Runner/Real.hs
@@ -9,7 +9,7 @@ import           System.Process.Typed      (ExitCode (ExitFailure, ExitSuccess),
                                             proc, readProcess)
 import           Universum
 
-runGit :: (MonadCatch m, MonadIO m) => Text -> m (Maybe Text)
+runGit :: (MonadIO m) => Text -> m (Maybe Text)
 runGit cmd = do
     (eCode, outputBS, _errBS) <- readProcess $ proc "git" (toString <$> words cmd)
     case eCode of

--- a/src/Elegit/Git/Runner/Simulated.hs
+++ b/src/Elegit/Git/Runner/Simulated.hs
@@ -10,8 +10,9 @@ import qualified Data.List.NonEmpty          as NE
 import qualified Elegit.Git.Action           as GA
 import           Fmt
 import           Lens.Micro
+import           Lens.Micro.Mtl
 import           Lens.Micro.TH
-import           Universum                   as U
+import           Universum  as U hiding ((^.), (%~), use, preuse, view)
 
 -- | Describes all the metrics we collect from the git action execution
 data GitCommand

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/22.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -65,3 +65,5 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+ghc-options:
+  '$everything': -haddock

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,8 +6,8 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 5098594e71bdefe0c13e9e6236f12e3414ef91a2b89b029fd30e8fc8087f3a07
-    size: 619399
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/22.yaml
+    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
+    size: 648660
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
   original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/22.yaml
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml

--- a/test/Elegit/Cli/Action/ShowWorkSpec.hs
+++ b/test/Elegit/Cli/Action/ShowWorkSpec.hs
@@ -4,8 +4,9 @@ import qualified Data.List.NonEmpty          as NE
 import qualified Elegit.Cli.Action.ShowWork  as ShowWork
 import           Elegit.Git.Runner.Simulated
 import           Lens.Micro
+import           Lens.Micro.Mtl
 import           Test.Hspec
-import           Universum
+import           Universum hiding ((^.), (.~), (%~), view)
 
 
 defaultRepository :: GRepository


### PR DESCRIPTION
Version `9.2.5` was selected as it's currently the latest LTS on `stackage`.

`Universum` deprecated reexported functions from `microlens` which forces us to hide them from `Unversum` imports. They will be removed in version `1.9.0`.

#284

The contribution:
- [ ] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [ ] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
