### PR TITLE
Encapsulate show-work command logic in one module

### DIFF
--- a/elegant-git.cabal
+++ b/elegant-git.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -52,6 +52,7 @@ library
     , mtl
     , optparse-applicative
     , safe-exceptions
+    , string-qq
     , text
     , transformers
     , typed-process
@@ -81,6 +82,7 @@ executable git-elegant
     , mtl
     , optparse-applicative
     , safe-exceptions
+    , string-qq
     , text
     , transformers
     , typed-process
@@ -114,6 +116,7 @@ test-suite elegant-git-test
     , mtl
     , optparse-applicative
     , safe-exceptions
+    , string-qq
     , text
     , transformers
     , typed-process

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - base >= 4.7 && < 5
 
 - universum
+- string-qq
 - text
 - safe-exceptions
 - fmt

--- a/src/Elegit/Cli/Action/ShowWork.hs
+++ b/src/Elegit/Cli/Action/ShowWork.hs
@@ -1,12 +1,46 @@
-module Elegit.Cli.Action.ShowWork where
+{-# LANGUAGE QuasiQuotes #-}
+module Elegit.Cli.Action.ShowWork
+    ( cmd
+    , cli
+    ) where
 
 import           Control.Monad.Free.Class
-import qualified Data.Text                as T
-import qualified Elegit.Git.Action        as GA
+import           Data.String.QQ
+import qualified Data.Text                       as T
+import           Elegit.Cli.Command
+import qualified Elegit.Git.Action               as GA
 import           Fmt
+import           Options.Applicative
+import qualified Options.Applicative.Help.Pretty as OA
 import           Universum
 
--- | Exectuion description of the AquireRepository action
+
+purpose :: OA.Doc
+purpose = OA.text "Prints HEAD state."
+
+description :: OA.Doc
+description = OA.string [s|
+Prints HEAD state by displaying local and remote-tracking (if available) refs,
+commits that aren't in the default development branch, uncommitted
+modifications, and available stashes.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-work
+git log --oneline master..@
+git status --short
+git stash list
+```|]
+
+
+cli :: Mod CommandFields ElegitCommand
+cli = command "show-work" $ info (pure ShowWorkCommand) $
+    mconcat [ progDescDoc (Just purpose )
+            , footerDoc (Just description )
+            ]
+
+
+-- | Execution description of the ShowWork action
 cmd :: (MonadFree GA.GitF m) => m ()
 cmd = do
     currentBranch <- GA.currentBranch

--- a/src/Elegit/Cli/Parser.hs
+++ b/src/Elegit/Cli/Parser.hs
@@ -1,6 +1,7 @@
 module Elegit.Cli.Parser where
 
-import           Elegit.Cli.Command  (ElegitCommand (ShowWorkCommand))
+import qualified Elegit.Cli.Action.ShowWork as ShowWork
+import           Elegit.Cli.Command
 import           Options.Applicative
 import           Universum
 
@@ -8,16 +9,10 @@ import           Universum
 type Command a = Mod CommandFields a
 
 
-showWorkCommand :: Command ElegitCommand
-showWorkCommand =
-    command "show-work" $
-        flip info (progDesc "Prints HEAD state.") $ pure ShowWorkCommand
-
-
 dayToDayContributionsCommand :: Command ElegitCommand
 dayToDayContributionsCommand =
-    commandGroup " make day-to-day contributions"
-    <> showWorkCommand
+    commandGroup "make day-to-day contributions"
+    <> ShowWork.cli
 
 
 cli :: ParserInfo ElegitCommand


### PR DESCRIPTION
Haskell does not have a way to create multiline strings, so we use the `string-qq` package and Haskell's `QuasiQuotes`.

I'm uncertain if this is the best way to encapsulate the logic in one module, but we can change this anytime in the future fairly easy.

#285

The contribution:
- [ ] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [ ] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
