### PR TITLE
Use help message of desired command

### DIFF
--- a/elegant-git.cabal
+++ b/elegant-git.cabal
@@ -94,6 +94,8 @@ test-suite elegant-git-test
   main-is: Spec.hs
   other-modules:
       Elegit.Cli.Action.ShowWorkSpec
+      Elegit.Cli.Parser.ShowWorkSpec
+      Elegit.Cli.Parser.Util
       Elegit.Git.Runner.SimulatedSpec
       Paths_elegant_git
   hs-source-dirs:

--- a/src/Elegit/Cli/Command.hs
+++ b/src/Elegit/Cli/Command.hs
@@ -1,4 +1,7 @@
 module Elegit.Cli.Command where
 
+import           Universum
+
 data ElegitCommand
     = ShowWorkCommand
+    deriving (Show, Eq)

--- a/src/Elegit/Cli/Parser.hs
+++ b/src/Elegit/Cli/Parser.hs
@@ -19,3 +19,11 @@ cli :: ParserInfo ElegitCommand
 cli = flip info mempty $
     hsubparser dayToDayContributionsCommand <**> helper
 
+
+cliPrefs :: ParserPrefs
+cliPrefs = prefs $
+  mconcat [ showHelpOnError
+          , showHelpOnEmpty
+          , noBacktrack
+          ]
+

--- a/src/Elegit/Git/Runner/Simulated.hs
+++ b/src/Elegit/Git/Runner/Simulated.hs
@@ -12,7 +12,8 @@ import           Fmt
 import           Lens.Micro
 import           Lens.Micro.Mtl
 import           Lens.Micro.TH
-import           Universum  as U hiding ((^.), (%~), use, preuse, view)
+import           Universum                   as U hiding (preuse, use, view,
+                                                   (%~), (^.))
 
 -- | Describes all the metrics we collect from the git action execution
 data GitCommand

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -4,16 +4,12 @@ import qualified Elegit.Cli.Action.ShowWork as ShowWork
 import           Elegit.Cli.Command         (ElegitCommand (..))
 import qualified Elegit.Cli.Parser          as P
 import           Elegit.Git.Runner.Real     (executeGit)
-import           Options.Applicative        (customExecParser, prefs,
-                                             showHelpOnEmpty, showHelpOnError)
+import           Options.Applicative        (customExecParser)
 import           Universum
 
 runCli :: (MonadIO m, MonadCatch m) => m ()
 runCli = do
-  let
-    cliPrefs = prefs $ showHelpOnError <> showHelpOnEmpty
-
-  cmd <- liftIO $ customExecParser cliPrefs P.cli
+  cmd <- liftIO $ customExecParser P.cliPrefs P.cli
 
   flip catch (\e -> putTextLn $ "Caught exception: " <> show (e :: SomeException) ) $
     executeGit $

--- a/test/Elegit/Cli/Action/ShowWorkSpec.hs
+++ b/test/Elegit/Cli/Action/ShowWorkSpec.hs
@@ -6,7 +6,7 @@ import           Elegit.Git.Runner.Simulated
 import           Lens.Micro
 import           Lens.Micro.Mtl
 import           Test.Hspec
-import           Universum hiding ((^.), (.~), (%~), view)
+import           Universum                   hiding (view, (%~), (.~), (^.))
 
 
 defaultRepository :: GRepository

--- a/test/Elegit/Cli/Parser/ShowWorkSpec.hs
+++ b/test/Elegit/Cli/Parser/ShowWorkSpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Elegit.Cli.Parser.ShowWorkSpec where
+
+import           Data.String.QQ
+import           Elegit.Cli.Command     (ElegitCommand (..))
+import           Elegit.Cli.Parser.Util as P
+import           Test.Hspec
+import           Universum
+
+
+helpText :: Text
+helpText = "Usage: git elegant show-work \n" <> [s|
+
+  Prints HEAD state.
+
+Available options:
+  -h,--help                Show this help text
+
+Prints HEAD state by displaying local and remote-tracking (if available) refs,
+commits that aren't in the default development branch, uncommitted
+modifications, and available stashes.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-work
+git log --oneline master..@
+git status --short
+git stash list
+```|]
+
+invalidArgumentHelp :: Text
+invalidArgumentHelp = [s|
+Invalid argument `test-arg'
+
+|] <> "Usage: git elegant show-work \n" <> [s|
+
+  Prints HEAD state.
+
+Available options:
+  -h,--help                Show this help text
+
+Prints HEAD state by displaying local and remote-tracking (if available) refs,
+commits that aren't in the default development branch, uncommitted
+modifications, and available stashes.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-work
+git log --oneline master..@
+git status --short
+git stash list
+```|]
+
+invalidOptionHelp :: Text
+invalidOptionHelp = [s|
+Invalid option `--test-arg'
+
+|] <> "Usage: git elegant show-work \n" <> [s|
+
+  Prints HEAD state.
+
+Available options:
+  -h,--help                Show this help text
+
+Prints HEAD state by displaying local and remote-tracking (if available) refs,
+commits that aren't in the default development branch, uncommitted
+modifications, and available stashes.
+
+Approximate commands flow is
+```bash
+==>> git elegant show-work
+git log --oneline master..@
+git status --short
+git stash list
+```|]
+
+spec :: Spec
+spec = do
+  describe "cmd" $ do
+    it "parses command succefully" $ do
+      parseMaybe "show-work" [] `shouldBe` Just ShowWorkCommand
+
+    it "renders command help" $ do
+      parseResult "show-work" ["--help"] `shouldRender` helpText
+
+    it "failes to parse unexpected arguments" $ do
+      parseResult "show-work" ["test-arg"] `shouldRender` invalidArgumentHelp
+
+    it "failes to parse unexpected options" $ do
+      parseResult "show-work" ["--test-arg"] `shouldRender` invalidOptionHelp

--- a/test/Elegit/Cli/Parser/Util.hs
+++ b/test/Elegit/Cli/Parser/Util.hs
@@ -1,0 +1,25 @@
+module Elegit.Cli.Parser.Util where
+
+
+import           Elegit.Cli.Command  (ElegitCommand (..))
+import           Elegit.Cli.Parser   as P
+import           Options.Applicative
+import           Test.Hspec          (Expectation, expectationFailure, shouldBe)
+import           Universum
+
+
+parseMaybe :: Text -> [Text] -> Maybe ElegitCommand
+parseMaybe cmd args =
+    getParseResult $ parseResult cmd args
+
+parseResult :: Text -> [Text] -> ParserResult ElegitCommand
+parseResult cmd args =
+    execParserPure P.cliPrefs P.cli (toString cmd: map toString args)
+
+shouldRender :: (Show a) => ParserResult a -> Text -> Expectation
+shouldRender parserResult expectedOutput =
+    case parserResult of
+        Failure pFailure ->
+            toText (fst $ renderFailure pFailure "git elegant") `shouldBe` expectedOutput
+        _ -> expectationFailure $
+            "Parser did not render anything. Parsing result: " <> show parserResult


### PR DESCRIPTION
Disable backtracking in cli parser.

Explanation:
In haskell, we have a pattern which allows us to try multiple options untill something succeedes. If option failed, we backtrack to the parent to try more. This has an advantage of allowing a high-level code to be insanely flexible.
This is where a problem lies: if we find the command `show-work` but then fail to parse arguments, with the `simple` implementation we have no way to know that we should commit to parse this message. In our case, the ideal approach is to just disable backtracking, as this will force parser to try parsing a specific command as soon as it found one.

#289

The contribution:
- [x] updates all affected documentation
- [ ] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [ ] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
