### PR TITLE
Configure stylish-haskell

### DIFF
--- a/.github/workflows/haskell-quality-pipeline.yml
+++ b/.github/workflows/haskell-quality-pipeline.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -13,6 +12,7 @@ env:
   GHC_VERSION: 9.2.4
   STACK_VERSION: 2.7.3
   HLINT_VERSION: 3.3.6
+  STYLISH_HASKELL_VERSION: v0.14.3.0
 
 jobs:
   tests:
@@ -37,12 +37,23 @@ jobs:
         ghc-version: '${{ env.GHC_VERSION }}'
         enable-stack: true
         stack-version: '${{ env.STACK_VERSION }}'
+    - name: Install stylish-haskell
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        echo "Installing stylish-haskell v${{ env.STYLISH_HASKELL_VERSION }}"
+        wget -O /tmp/stylish-haskell-${{ env.STYLISH_HASKELL_VERSION }}.tar.gz https://github.com/haskell/stylish-haskell/releases/download/${{ env.STYLISH_HASKELL_VERSION }}/stylish-haskell-${{ env.STYLISH_HASKELL_VERSION }}-linux-x86_64.tar.gz
+        tar -xf /tmp/stylish-haskell-${{ env.STYLISH_HASKELL_VERSION }}.tar.gz -C /tmp
+        cp /tmp/stylish-haskell-${{ env.STYLISH_HASKELL_VERSION }}-linux-x86_64/stylish-haskell ~/.ghcup/bin/stylish-haskell
     - name: Install hlint
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        echo "Installing hlint v${{ env.HLINT_VERSION }}"
         wget -O /tmp/hlint-${{ env.HLINT_VERSION }}.tar.gz https://github.com/ndmitchell/hlint/releases/download/v${{ env.HLINT_VERSION }}/hlint-${{ env.HLINT_VERSION }}-x86_64-linux.tar.gz
         tar -xf /tmp/hlint-${{ env.HLINT_VERSION }}.tar.gz -C /tmp
         cp /tmp/hlint-${{ env.HLINT_VERSION }}/hlint ~/.ghcup/bin/hlint
+    - name: Run stylish-haskell
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: stylish-haskell src app test/Elegit/* -r > /dev/null
     - name: Run hlint
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: hlint .

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,372 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  - module_header:
+      # How many spaces use for indentation in the module header.
+      indent: 4
+
+      # Should export lists be sorted?  Sorting is only performed within the
+      # export section, as delineated by Haddock comments.
+      sort: true
+
+      # See `separate_lists` for the `imports` step.
+      separate_lists: true
+
+      # When to break the "where".
+      # Possible values:
+      # - exports: only break when there is an explicit export list.
+      # - single: only break when the export list counts more than one export.
+      # - inline: only break when the export list is too long. This is
+      #   determined by the `columns` setting. Not applicable when the export
+      #   list contains comments as newlines will be required.
+      # - always: always break before the "where".
+      # break_where: exports
+
+      # Where to put open bracket
+      # Possible values:
+      # - same_line: put open bracket on the same line as the module name, before the
+      #              comment of the module
+      # - next_line: put open bracket on the next line, after module comment
+      # open_bracket: next_line
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  - records:
+      # How to format equals sign between type constructor and data constructor.
+      # Possible values:
+      # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+      # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+      equals: "indent 2"
+
+      # How to format first field of each record constructor.
+      # Possible values:
+      # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+      # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+      first_field: "indent 2"
+
+      # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+      field_comment: 2
+
+      # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+      deriving: 2
+
+      # How many spaces to insert before "via" clause counted from indentation of deriving clause
+      # Possible values:
+      # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+      # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+      via: "indent 2"
+
+      # Sort typeclass names in the "deriving" list alphabetically.
+      sort_deriving: true
+
+      # Whether or not to break enums onto several lines
+      #
+      # Default: false
+      break_enums: true
+
+      # Whether or not to break single constructor data types before `=` sign
+      #
+      # Default: true
+      break_single_constructors: true
+
+      # Whether or not to curry constraints on function.
+      #
+      # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+      #
+      # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+      #
+      # Default: false
+      curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Post qualify option moves any qualifies found in import declarations
+      # to the end of the declaration. This also adjust padding for any
+      # unqualified import declarations.
+      #
+      # - true: Qualified as <module name> is moved to the end of the
+      #   declaration.
+      #
+      #   > import Data.Bar
+      #   > import Data.Foo qualified as F
+      #
+      # - false: Qualified remains in the default location and unqualified
+      #   imports are padded to align with qualified imports.
+      #
+      #   > import           Data.Bar
+      #   > import qualified Data.Foo as F
+      #
+      # Default: false
+      post_qualify: false
+
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-# LANGUAGE #-}'.
+      #
+      # - vertical_compact: Similar to vertical, but use only one language pragma.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 120
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true
+
+exit_code: error_on_format

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+    ( main
+    ) where
 
 import           Lib
 import           Universum

--- a/src/Elegit/Cli/Action/ShowWork.hs
+++ b/src/Elegit/Cli/Action/ShowWork.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Elegit.Cli.Action.ShowWork
-    ( cmd
-    , cli
+    ( cli
+    , cmd
     ) where
 
 import           Control.Monad.Free.Class
@@ -54,7 +54,7 @@ cmd = do
     GA.reportInfo (fmt "local: "+|currentBranch|+"")
     case mCurrentUpstream of
       Just currentUpstream -> GA.reportInfo (fmt "remote: "+|currentUpstream|+"")
-      Nothing -> pass
+      Nothing              -> pass
 
     GA.reportInfo ""
 

--- a/src/Elegit/Cli/Command.hs
+++ b/src/Elegit/Cli/Command.hs
@@ -3,5 +3,5 @@ module Elegit.Cli.Command where
 import           Universum
 
 data ElegitCommand
-    = ShowWorkCommand
-    deriving (Show, Eq)
+  = ShowWorkCommand
+  deriving (Eq, Show)

--- a/src/Elegit/Git/Action.hs
+++ b/src/Elegit/Git/Action.hs
@@ -61,29 +61,28 @@ import           Universum
 --
 -- TODO: Use records
 data GitF a
-    = CurrentBranch (Text -> a)
-    | BranchUpstream Text (Maybe Text -> a)
-    | Log LogType Text Text ([Text] -> a)
-    | Status StatusType ([Text] -> a)
-    | StashList ([Text] -> a)
-
-    | ReportInfo Text a
-    | PrintText Text a
-    deriving stock (Functor)
+  = CurrentBranch (Text -> a)
+  | BranchUpstream Text (Maybe Text -> a)
+  | Log LogType Text Text ([Text] -> a)
+  | Status StatusType ([Text] -> a)
+  | StashList ([Text] -> a)
+  | ReportInfo Text a
+  | PrintText Text a
+  deriving stock (Functor)
 
 
 -- | Represents types of git status output
 --
 -- `StatusShort` is the same as "--short" option.
 data StatusType
-    = StatusShort
+  = StatusShort
 
 
 -- | Represents types of git log output
 --
 -- `LogOneLine` is the same as "--oneline" option.
 data LogType
-    = LogOneLine
+  = LogOneLine
 
 
 -- | Type alias to the `Free` `GitF` monad.

--- a/src/Elegit/Git/Runner/Real.hs
+++ b/src/Elegit/Git/Runner/Real.hs
@@ -5,8 +5,7 @@ import           Control.Monad.Free.Church
 import           Data.Text                 (stripEnd)
 import qualified Elegit.Git.Action         as GA
 import           Fmt
-import           System.Process.Typed      (ExitCode (ExitFailure, ExitSuccess),
-                                            proc, readProcess)
+import           System.Process.Typed      (ExitCode (ExitFailure, ExitSuccess), proc, readProcess)
 import           Universum
 
 runGit :: (MonadIO m) => Text -> m (Maybe Text)

--- a/src/Elegit/Git/Runner/Simulated.hs
+++ b/src/Elegit/Git/Runner/Simulated.hs
@@ -12,68 +12,62 @@ import           Fmt
 import           Lens.Micro
 import           Lens.Micro.Mtl
 import           Lens.Micro.TH
-import           Universum                   as U hiding (preuse, use, view,
-                                                   (%~), (^.))
+import           Universum                   as U hiding (preuse, use, view, (%~), (^.))
 
 -- | Describes all the metrics we collect from the git action execution
 data GitCommand
-    = UpdateConfigCommand Text Text
-    | CloneRepositoryCommand Text
-    | ReportInfo Text
-    | PrintText Text
-    deriving stock (Show, Eq)
+  = UpdateConfigCommand Text Text
+  | CloneRepositoryCommand Text
+  | ReportInfo Text
+  | PrintText Text
+  deriving stock (Eq, Show)
 
 -- TODO: Add commit hash.
 newtype GCommit
-    = GCommit
-        { _gcName :: Text
-        }
-    deriving (Show, Eq)
+  = GCommit { _gcName :: Text }
+  deriving (Eq, Show)
 
 makeLenses ''GCommit
 
 
 data GBranch
-    = GBranch
-        { _gbName     :: Text
-        , _gbUpstream :: Maybe Text
-        , _gbCommit   :: NonEmpty GCommit
-        }
-    deriving (Show, Eq)
+  = GBranch
+      { _gbName     :: Text
+      , _gbUpstream :: Maybe Text
+      , _gbCommit   :: NonEmpty GCommit
+      }
+  deriving (Eq, Show)
 
 makeLenses ''GBranch
 
 
 data GStash
-    = GStash
-        { _gsName       :: Text
-        , _gsBranchName :: Text
-        }
-    deriving (Show, Eq)
+  = GStash
+      { _gsName       :: Text
+      , _gsBranchName :: Text
+      }
+  deriving (Eq, Show)
 
 makeLenses ''GStash
 
 
 newtype GRemote
-    = GRemote
-        { _grmName :: Text
-        -- , _grmUrl :: Text
-        }
-    deriving (Show, Eq)
+  = GRemote { _grmName :: Text }
+  deriving (Eq, Show)
 
 makeLenses ''GRemote
 
 
 data GRepository
-    = GRepository
-        { _grRemotes       :: [GRemote]
-        , _grBranches      :: [GBranch]
-        , _grCurrentBranch :: Text
-        , _grStashes       :: [GStash]
-        , _grModifiedFiles :: [Text]
-        , _grUnstagedFiles :: [Text]
-        }
-    deriving (Show, Eq)
+  = GRepository
+      { _grRemotes       :: [GRemote]
+      , _grBranches      :: [GBranch]
+      , _grCurrentBranch :: Text
+      , _grStashes       :: [GStash]
+      , _grModifiedFiles :: [Text]
+      , _grUnstagedFiles :: [Text]
+      }
+  deriving (Eq, Show)
 
 
 -- greatestCommonAncestor :: [GCommit] -> [GCommit] -> Maybe GCommit


### PR DESCRIPTION
`stylish-haskell` tool is in my opinion is the easiest one to configure and provides best looking result for my tastes.

#290

The contribution:
- [x] updates all affected documentation
- [ ] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [ ] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
