### PR TITLE
Implement acquire repository command

### DIFF
--- a/elegant-git.cabal
+++ b/elegant-git.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+      Elegit.Cli.Action.AcquireRepository
       Elegit.Cli.Action.ShowWork
       Elegit.Cli.Command
       Elegit.Cli.Parser
@@ -43,6 +44,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Werror=incomplete-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
+    , containers
     , dlist
     , fmt
     , free
@@ -57,6 +59,8 @@ library
     , transformers
     , typed-process
     , universum
+    , unordered-containers
+    , utility-ht
   default-language: Haskell2010
 
 executable git-elegant
@@ -72,6 +76,7 @@ executable git-elegant
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Werror=incomplete-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers
     , dlist
     , elegant-git
     , fmt
@@ -87,13 +92,17 @@ executable git-elegant
     , transformers
     , typed-process
     , universum
+    , unordered-containers
+    , utility-ht
   default-language: Haskell2010
 
 test-suite elegant-git-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Elegit.Cli.Action.AcquireRepositorySpec
       Elegit.Cli.Action.ShowWorkSpec
+      Elegit.Cli.Parser.AcquireRepositorySpec
       Elegit.Cli.Parser.ShowWorkSpec
       Elegit.Cli.Parser.Util
       Elegit.Git.Runner.SimulatedSpec
@@ -107,6 +116,7 @@ test-suite elegant-git-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Werror=incomplete-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers
     , dlist
     , elegant-git
     , fmt
@@ -123,4 +133,6 @@ test-suite elegant-git-test
     , transformers
     , typed-process
     , universum
+    , unordered-containers
+    , utility-ht
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -31,9 +31,12 @@ dependencies:
 - mtl
 - free
 - dlist
+- containers
+- unordered-containers
 - microlens
 - microlens-mtl
 - microlens-th
+- utility-ht
 
 - optparse-applicative
 - typed-process

--- a/src/Elegit/Cli/Action/AcquireRepository.hs
+++ b/src/Elegit/Cli/Action/AcquireRepository.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Elegit.Cli.Action.AcquireRepository
+    ( cli
+    , cmd
+    ) where
+
+import           Control.Monad.Free.Class
+import           Data.String.QQ
+import           Elegit.Cli.Command
+import qualified Elegit.Git.Action               as GA
+import           Fmt
+import           Options.Applicative
+import qualified Options.Applicative.Help.Pretty as OA
+import           Universum
+
+
+site:: Text
+site = "placeholder"
+
+purpose :: OA.Doc
+purpose = OA.text "Configures the current local Git repository."
+
+description :: OA.Doc
+description = OA.string $ [s|
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using `git config --local`. The command asks to
+provide information that is needed for the current repository configuration.
+
+The behavior of the command varies depend on `git elegant acquire-git`
+execution (a global configuration). If the global configuration is applied,
+then this command configures repository-related staffs only, otherwise, it
+applies all configurations to the current local repository.
+
+To find out what will be configured, please visit
+|] ++ (fmt ""+|site|+"/en/latest/configuration/")
+
+
+cli :: Mod CommandFields ElegitCommand
+cli = command "acquire-repository" $ info (pure AcquireRepositoryCommand) $
+    mconcat [ progDescDoc (Just purpose )
+            , footerDoc (Just description )
+            ]
+
+
+data ConfigKey
+  = UserNameKey
+  | UserEmailKey
+  | CoreEditorKey
+  | DefaultBranchKey
+  | ProtectedBranchesKey
+
+
+configName :: ConfigKey -> Text
+configName UserNameKey          = "user.name"
+configName UserEmailKey         = "user.email"
+configName CoreEditorKey        = "core.editor"
+configName DefaultBranchKey     = "elegant-git.default-branch"
+configName ProtectedBranchesKey = "elegant-git.protected-branches"
+
+
+configPrompt :: ConfigKey -> Text
+configPrompt UserNameKey          = "What is your user name?"
+configPrompt UserEmailKey         = "What is your email?"
+configPrompt CoreEditorKey        = "What is the command to launching an editor?"
+configPrompt DefaultBranchKey     = "What is the default branch?"
+configPrompt ProtectedBranchesKey = "What are protected branches (split with space)"
+
+
+configDefault :: (MonadFree GA.GitF m) => ConfigKey -> m (Maybe Text)
+configDefault cKey = case cKey of
+    UserNameKey          -> getFromConfig
+    UserEmailKey         -> getFromConfig
+    CoreEditorKey        -> getFromConfig
+    DefaultBranchKey     -> return $ Just "master"
+    ProtectedBranchesKey -> return $ Just "master"
+
+    where
+        getFromConfig :: (MonadFree GA.GitF m) => m (Maybe Text)
+        getFromConfig = GA.readConfig GA.AutoConfig (configName cKey)
+
+
+configureBasics :: (MonadFree GA.GitF m) => GA.ConfigScope -> m ()
+configureBasics cScope = do
+    for_ basicConfigs $ \cKey -> do
+        keyDefault <- configDefault cKey
+        newValue <- GA.promptDefault (configPrompt cKey) keyDefault
+        GA.setConfigVerbose cScope (configName cKey) newValue
+
+    where
+        basicConfigs :: [ConfigKey]
+        basicConfigs =
+            [ UserNameKey
+            , UserEmailKey
+            , CoreEditorKey
+            , DefaultBranchKey
+            , ProtectedBranchesKey
+            ]
+
+
+configureStandards :: (MonadFree GA.GitF m) => GA.ConfigScope -> m ()
+configureStandards cScope =
+    for_ standardConfigs $ \(cKey,cValue) -> do
+        GA.setConfigVerbose cScope cKey cValue
+    where
+        standardConfigs :: [(Text, Text)]
+        standardConfigs =
+            [ ("core.commentChar", "|")
+            , ("apply.whitespace", "fix")
+            , ("fetch.prune", "true")
+            , ("fetch.pruneTags", "false")
+            , ("core.autocrlf", "input")
+            , ("pull.rebase", "true")
+            , ("rebase.autoStash", "false")
+            , ("credential.helper", "osxkeychain")
+            ]
+
+
+configureAliases :: (MonadFree GA.GitF m) => GA.ConfigScope -> m ()
+configureAliases cScope = do
+    forM_ elegantCommands $ \elegantCommand -> do
+        let
+            alias = "alias."+|elegantCommand|+""
+            origin = "elegant "+|elegantCommand|+""
+        GA.setConfigVerbose cScope alias origin
+    where
+        -- TODO: Think if there is a way to make it centralised
+        elegantCommands :: [Text]
+        elegantCommands =
+            [ "accept-work"
+            , "acquire-git"
+            , "acquire-repository"
+            , "actualize-work"
+            , "amend-work"
+            , "clone-repository"
+            , "deliver-work"
+            , "init-repository"
+            , "make-workflow"
+            , "obtain-work"
+            , "polish-work"
+            , "polish-workflow"
+            , "prune-repository"
+            , "release-work"
+            , "save-work"
+            , "show-commands"
+            , "show-release-notes"
+            , "show-work"
+            , "show-workflows"
+            , "start-work"
+            ]
+
+
+-- TODO: port bash logic
+setupGPGSignature :: (MonadFree GA.GitF m) => m ()
+setupGPGSignature = pass
+
+
+-- | Execution description of the AcquireRepository action
+cmd :: (MonadFree GA.GitF m) => m ()
+cmd = do
+    GA.removeObsoleteConfiguration GA.LocalConfig
+    GA.print =<< GA.formatInfoBox "Configuring basics..."
+    configureBasics GA.LocalConfig
+    unlessM GA.isGitAcquired $ do
+        GA.print =<< GA.formatInfoBox "Configuring standards..."
+        configureStandards GA.LocalConfig
+        GA.print =<< GA.formatInfoBox "Configuring aliases..."
+        configureAliases GA.LocalConfig
+    GA.print =<< GA.formatInfoBox "Configuring signature..."
+    setupGPGSignature

--- a/src/Elegit/Cli/Action/ShowWork.hs
+++ b/src/Elegit/Cli/Action/ShowWork.hs
@@ -50,24 +50,25 @@ cmd = do
     changes <- GA.status GA.StatusShort
     stashes <- GA.stashList
 
-    GA.reportInfo ">>> Branch refs:"
-    GA.reportInfo (fmt "local: "+|currentBranch|+"")
+    GA.print =<< GA.formatInfo ">>> Branch refs:"
+    GA.print =<< GA.formatInfo (fmt "local: "+|currentBranch|+"")
     case mCurrentUpstream of
-      Just currentUpstream -> GA.reportInfo (fmt "remote: "+|currentUpstream|+"")
-      Nothing              -> pass
+      Nothing -> pass
+      Just currentUpstream ->
+          GA.print =<< GA.formatInfo (fmt "remote: "+|currentUpstream|+"")
 
-    GA.reportInfo ""
+    GA.print ""
 
     unless (null logs) $ do
-        GA.reportInfo (fmt ">>> New commits (comparing to "+|branchWithLatestChanges|+" branch):")
+        GA.print =<< GA.formatInfo (fmt ">>> New commits (comparing to "+|branchWithLatestChanges|+" branch):")
         GA.print $ T.intercalate "\n" logs
-        GA.reportInfo ""
+        GA.print ""
 
     unless (null changes) $ do
-        GA.reportInfo ">>> Uncommitted modifications:"
+        GA.print =<< GA.formatInfo ">>> Uncommitted modifications:"
         GA.print $ T.intercalate "\n" changes
-        GA.reportInfo ""
+        GA.print ""
 
     unless (null stashes) $ do
-        GA.reportInfo ">>> Available stashes:"
+        GA.print =<< GA.formatInfo ">>> Available stashes:"
         GA.print $ T.intercalate "\n" stashes

--- a/src/Elegit/Cli/Command.hs
+++ b/src/Elegit/Cli/Command.hs
@@ -4,4 +4,5 @@ import           Universum
 
 data ElegitCommand
   = ShowWorkCommand
+  | AcquireRepositoryCommand
   deriving (Eq, Show)

--- a/src/Elegit/Cli/Parser.hs
+++ b/src/Elegit/Cli/Parser.hs
@@ -1,6 +1,7 @@
 module Elegit.Cli.Parser where
 
-import qualified Elegit.Cli.Action.ShowWork as ShowWork
+import qualified Elegit.Cli.Action.AcquireRepository as AcquireRepository
+import qualified Elegit.Cli.Action.ShowWork          as ShowWork
 import           Elegit.Cli.Command
 import           Options.Applicative
 import           Universum
@@ -13,6 +14,7 @@ dayToDayContributionsCommand :: Command ElegitCommand
 dayToDayContributionsCommand =
     commandGroup "make day-to-day contributions"
     <> ShowWork.cli
+    <> AcquireRepository.cli
 
 
 cli :: ParserInfo ElegitCommand

--- a/src/Elegit/Git/Runner/Simulated.hs
+++ b/src/Elegit/Git/Runner/Simulated.hs
@@ -1,26 +1,33 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE TemplateHaskell    #-}
 module Elegit.Git.Runner.Simulated where
 
 import           Control.Monad.Free.Church
+import           Control.Monad.HT            (until)
 import           Control.Monad.Writer.Strict
 import           Data.DList                  as DList
+import qualified Data.HashMap.Strict         as HS
 import qualified Data.List.NonEmpty          as NE
+import qualified Data.Text                   as T
 import qualified Elegit.Git.Action           as GA
 import           Fmt
 import           Lens.Micro
 import           Lens.Micro.Mtl
 import           Lens.Micro.TH
-import           Universum                   as U hiding (preuse, use, view, (%~), (^.))
+import           Universum                   as U hiding (Lens, Lens', Traversal', preuse, use, view, (%~), (^.))
 
 -- | Describes all the metrics we collect from the git action execution
 data GitCommand
   = UpdateConfigCommand Text Text
   | CloneRepositoryCommand Text
-  | ReportInfo Text
+  | Prompt Text
   | PrintText Text
   deriving stock (Eq, Show)
+
+
+type GConfig = HashMap Text Text
 
 -- TODO: Add commit hash.
 newtype GCommit
@@ -66,13 +73,23 @@ data GRepository
       , _grStashes       :: [GStash]
       , _grModifiedFiles :: [Text]
       , _grUnstagedFiles :: [Text]
+      , _grConfig        :: GConfig
       }
   deriving (Eq, Show)
 
 
--- greatestCommonAncestor :: [GCommit] -> [GCommit] -> Maybe GCommit
--- greatestCommonAncestor left right =
+makeLenses ''GRepository
 
+
+data InMemoryGit
+  = IMGit
+      { _gRepository :: GRepository
+      , _gConfig     :: GConfig
+      }
+  deriving (Eq, Show)
+
+
+makeLenses ''InMemoryGit
 
 
 commitDifference :: GCommit -> [GCommit] -> [GCommit]
@@ -82,15 +99,13 @@ commitDifference bc (tc : tcs)
     | otherwise = tc: commitDifference bc tcs
 
 
-makeLenses ''GRepository
-
-
 -- | Collects a summary of execution as a list of `GitCommand`s.
-runGitActionPure :: GRepository -> GA.FreeGit () -> (GRepository, [GitCommand])
-runGitActionPure gr action =
-    let
-        (commands, repo) = runIdentity $ flip runStateT gr $ execWriterT $ foldF collectImpureCommandsF action
-    in (repo, DList.toList commands)
+runGitActionPure :: InMemoryGit -> GA.FreeGit () -> (InMemoryGit, [GitCommand])
+runGitActionPure imGit action =
+  let
+    (commands, imGit') = runIdentity $ flip runStateT imGit $ execWriterT $ foldF collectImpureCommandsF action
+  in (imGit', DList.toList commands)
+
 
 -- | Interpreter of GitF which collects the summary of exection in `Writer` monad.
 --
@@ -102,49 +117,136 @@ runGitActionPure gr action =
 --
 -- Note that we are in the context of the `Writer` monad and we need to wrap the value `a` in
 -- `Writer`. To lift any value into a monad you should use `return`.
-collectImpureCommandsF :: (MonadState GRepository m, MonadWriter (DList GitCommand) m) => GA.GitF a -> m a
+collectImpureCommandsF :: (MonadState InMemoryGit m, MonadWriter (DList GitCommand) m) => GA.GitF a -> m a
 collectImpureCommandsF cmd = case cmd of
-    GA.CurrentBranch next -> do
-        currentBranchName <- use grCurrentBranch
-        return $ next currentBranchName
-    GA.BranchUpstream branch next -> do
-        branches <- use grBranches
-        return $ next (find (\b -> b^.gbName == branch) branches >>= _gbUpstream)
+  GA.CurrentBranch next -> do
+    currentBranchName <- use $ localRepository . grCurrentBranch
+    return $ next currentBranchName
+  GA.BranchUpstream branch next -> do
+    branchM <- preuse $ localRepository . branchWithName branch
+    return $ next (branchM >>= _gbUpstream)
 
-    GA.Log lType base target next -> do
-        case lType of
-            GA.LogOneLine -> do
-                mBaseBranch <- preuse $ grBranches . each . filtered (\b -> b ^. gbName == base)
-                mTargetBranch <- preuse $ grBranches . each . filtered (\b -> b ^. gbName == target)
+  GA.Log lType base target next -> do
+    case lType of
+      GA.LogOneLine -> do
+        mBaseBranch <- preuse $ localRepository . branchWithName base
+        mTargetBranch <- preuse $ localRepository . branchWithName target
 
-                return $ next $ fromMaybe [] $ do
-                    baseBranch <- mBaseBranch
-                    targetBranch <- mTargetBranch
-                    let baseBranchHead = baseBranch ^. gbCommit.to U.head
-                    return $ view gcName <$> commitDifference baseBranchHead (NE.toList $ targetBranch^.gbCommit)
+        return $ next $ fromMaybe [] $ do
+          baseBranch <- mBaseBranch
+          targetBranch <- mTargetBranch
+          let baseBranchHead = baseBranch ^. gbCommit.to U.head
+          return $ view gcName <$> commitDifference baseBranchHead (NE.toList $ targetBranch^.gbCommit)
 
-    GA.Status sType next -> do
-        case sType of
-            GA.StatusShort -> do
-                modifiedFiles <- use grModifiedFiles
-                unstagedFiles <- use grUnstagedFiles
-                let
-                    modified :: [Text]
-                    modified = (\modifiedFile -> fmt "M "+|modifiedFile|+"") <$> modifiedFiles
-                    unstaged :: [Text]
-                    unstaged = (\unstagedFile -> fmt "?? "+|unstagedFile|+"") <$> unstagedFiles
-                return $ next (modified <> unstaged)
+  GA.Status sType next -> do
+    case sType of
+      GA.StatusShort -> do
+        modifiedFiles <- use $ localRepository . grModifiedFiles
+        unstagedFiles <- use $ localRepository . grUnstagedFiles
+        let
+          modified :: [Text]
+          modified = (\modifiedFile -> fmt "M "+|modifiedFile|+"") <$> modifiedFiles
+          unstaged :: [Text]
+          unstaged = (\unstagedFile -> fmt "?? "+|unstagedFile|+"") <$> unstagedFiles
+        return $ next (modified <> unstaged)
 
-    GA.StashList next -> do
-        stashes <- use grStashes
-        return $ next
-            [ fmt "stash@{"+||i||+"}: "+|(stash^.gsName)|+" on "+|(stash^.gsBranchName)|+"" | (i, stash) <- zip [(0 :: Int)..] stashes
-            ] -- this is excessive, I guess? @teggotic
+  GA.StashList next -> do
+    stashes <- use $ localRepository . grStashes
+    return $ next
+      [ fmt "stash@{"+||i||+"}: "+|(stash^.gsName)|+" on "+|(stash^.gsBranchName)|+"" | (i, stash) <- zip [(0 :: Int)..] stashes
+      ] -- this is excessive, I guess? @teggotic
 
-    GA.ReportInfo content next -> do
-        tell $ singleton $ ReportInfo content
-        return next
-    GA.PrintText content next -> do
-        -- make each line a separate print to make it easier to write test cases
-        tell $ DList.fromList (PrintText <$> lines content)
-        return next
+  GA.AliasesToRemove cScope next -> do
+    case cScope of
+     GA.LocalConfig -> do
+       cfg <- use $ localRepository . grConfig
+       let aliases = sort $ keys $ HS.filterWithKey (\k v -> "alias." `T.isPrefixOf` k && "elegant " `T.isPrefixOf` v) cfg
+       return $ next $ nonEmpty aliases
+     GA.GlobalConfig -> do
+       return $ next Nothing
+     GA.AutoConfig ->
+       -- TODO: Maybe work with local as default. Or narrow options
+       error "scope AutoConfig is not supported by AliasesToRemove"
+
+  GA.ReadConfig cScope cName next -> do
+    localCfg <- use localConfig
+    globalCfg <- use globalConfig
+    let
+      -- Note: Haskell is lazy and these will only be evaluated if needed depending on the branch
+      localValue = HS.lookup cName localCfg
+      globalValue = HS.lookup cName globalCfg
+    case cScope of
+          GA.LocalConfig  ->
+            return $ next localValue
+          GA.GlobalConfig ->
+            return $ next globalValue
+          GA.AutoConfig   ->
+            return $ next $ localValue <|> globalValue
+
+  GA.SetConfig cScope cName cValue next -> do
+    case cScope of
+     GA.LocalConfig -> do
+      localConfig %= HS.insert cName cValue
+     GA.GlobalConfig -> do
+      globalConfig %= HS.insert cName cValue
+     GA.AutoConfig  -> do
+      localConfig %= HS.insert cName cValue
+    return next
+
+  GA.UnsetConfig cScope cName next -> do
+    case cScope of
+     GA.LocalConfig -> do
+      localConfig %= HS.delete cName
+     GA.GlobalConfig -> do
+      globalConfig %= HS.delete cName
+     GA.AutoConfig  -> do
+      localConfig %= HS.delete cName
+    return next
+
+  GA.Prompt prompt pDefaultM next -> do
+    let
+      -- TODO: Make configurable
+      hardcodedAnswer :: Text
+      hardcodedAnswer = "test"
+
+      promptAnswer = do
+        tell $ singleton $ Prompt (message <> hardcodedAnswer)
+        return hardcodedAnswer
+
+      message :: Text
+      message =
+        case pDefaultM of
+         Just pDefault -> fmt ""+|prompt|+" {"+|pDefault|+"}: "
+         Nothing       -> fmt ""+|prompt|+": "
+
+    answer <- case pDefaultM of
+       Nothing -> until (not . null) promptAnswer
+       Just pDefault -> do
+         answer <- promptAnswer
+         if null answer
+           then return pDefault
+           else return answer
+    return $ next answer
+
+  GA.FormatInfo content next -> do
+    return $ next content
+  GA.FormatCommand content next -> do
+    return $ next ("==>> " <> content)
+  GA.PrintText content next -> do
+    -- make each line a separate print to make it easier to write test cases
+    tell $ if null content
+         then singleton $ PrintText ""
+         else DList.fromList (PrintText <$> lines content)
+    return next
+
+localRepository :: Lens' InMemoryGit GRepository
+localRepository = gRepository
+
+localConfig :: Lens' InMemoryGit GConfig
+localConfig = localRepository . grConfig
+
+globalConfig :: Lens' InMemoryGit GConfig
+globalConfig = gConfig
+
+branchWithName :: Text -> Traversal' GRepository GBranch
+branchWithName name = grBranches . each . filtered (\b -> b ^. gbName == name)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,10 +1,11 @@
 module Lib where
 
-import qualified Elegit.Cli.Action.ShowWork as ShowWork
-import           Elegit.Cli.Command         (ElegitCommand (..))
-import qualified Elegit.Cli.Parser          as P
-import           Elegit.Git.Runner.Real     (executeGit)
-import           Options.Applicative        (customExecParser)
+import qualified Elegit.Cli.Action.AcquireRepository as AcquireRepository
+import qualified Elegit.Cli.Action.ShowWork          as ShowWork
+import           Elegit.Cli.Command                  (ElegitCommand (..))
+import qualified Elegit.Cli.Parser                   as P
+import           Elegit.Git.Runner.Real              (executeGit)
+import           Options.Applicative                 (customExecParser)
 import           Universum
 
 runCli :: (MonadIO m, MonadCatch m) => m ()
@@ -14,4 +15,5 @@ runCli = do
   flip catch (\e -> putTextLn $ "Caught exception: " <> show (e :: SomeException) ) $
     executeGit $
       case cmd of
-         ShowWorkCommand -> ShowWork.cmd
+         ShowWorkCommand          -> ShowWork.cmd
+         AcquireRepositoryCommand -> AcquireRepository.cmd

--- a/test/Elegit/Cli/Action/AcquireRepositorySpec.hs
+++ b/test/Elegit/Cli/Action/AcquireRepositorySpec.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE OverloadedLists #-}
+module Elegit.Cli.Action.AcquireRepositorySpec where
+
+import           Data.HashMap.Strict                 (delete, union)
+import qualified Elegit.Cli.Action.AcquireRepository as AcquireRepository
+import           Elegit.Git.Runner.Simulated
+import           Lens.Micro
+import           Test.Hspec
+import           Universum                           hiding (view, (%~), (.~), (^.))
+
+
+defaultGit :: InMemoryGit
+defaultGit =
+  imGit
+  where
+    imGit = IMGit
+      { _gConfig = mempty
+      , _gRepository = repo
+      }
+    repo = GRepository
+       { _grRemotes = []
+       , _grBranches = [mainBranch, currentBranch]
+       , _grCurrentBranch = currentBranch^.gbName
+       , _grModifiedFiles = []
+       , _grUnstagedFiles = []
+       , _grStashes = []
+       , _grConfig = []
+       }
+    commit = GCommit
+      { _gcName = "Init commit"
+      }
+    mainBranch = GBranch
+      { _gbName = "main"
+      , _gbUpstream = Nothing
+      , _gbCommit = pure commit
+      }
+    currentBranch = GBranch
+      { _gbName = "haskell"
+      , _gbUpstream = Nothing
+      , _gbCommit = pure commit
+      }
+
+standardsOutputBlock :: [GitCommand]
+standardsOutputBlock =
+  [ PrintText "=============================="
+  , PrintText "== Configuring standards... =="
+  , PrintText "=============================="
+  , PrintText "==>> git config --local core.commentChar |"
+  , PrintText "==>> git config --local apply.whitespace fix"
+  , PrintText "==>> git config --local fetch.prune true"
+  , PrintText "==>> git config --local fetch.pruneTags false"
+  , PrintText "==>> git config --local core.autocrlf input"
+  , PrintText "==>> git config --local pull.rebase true"
+  , PrintText "==>> git config --local rebase.autoStash false"
+  , PrintText "==>> git config --local credential.helper osxkeychain"
+  ]
+
+aliasesOutputBlock :: [GitCommand]
+aliasesOutputBlock =
+  [ PrintText "============================"
+  , PrintText "== Configuring aliases... =="
+  , PrintText "============================"
+  , PrintText "==>> git config --local alias.accept-work elegant accept-work"
+  , PrintText "==>> git config --local alias.acquire-git elegant acquire-git"
+  , PrintText "==>> git config --local alias.acquire-repository elegant acquire-repository"
+  , PrintText "==>> git config --local alias.actualize-work elegant actualize-work"
+  , PrintText "==>> git config --local alias.amend-work elegant amend-work"
+  , PrintText "==>> git config --local alias.clone-repository elegant clone-repository"
+  , PrintText "==>> git config --local alias.deliver-work elegant deliver-work"
+  , PrintText "==>> git config --local alias.init-repository elegant init-repository"
+  , PrintText "==>> git config --local alias.make-workflow elegant make-workflow"
+  , PrintText "==>> git config --local alias.obtain-work elegant obtain-work"
+  , PrintText "==>> git config --local alias.polish-work elegant polish-work"
+  , PrintText "==>> git config --local alias.polish-workflow elegant polish-workflow"
+  , PrintText "==>> git config --local alias.prune-repository elegant prune-repository"
+  , PrintText "==>> git config --local alias.release-work elegant release-work"
+  , PrintText "==>> git config --local alias.save-work elegant save-work"
+  , PrintText "==>> git config --local alias.show-commands elegant show-commands"
+  , PrintText "==>> git config --local alias.show-release-notes elegant show-release-notes"
+  , PrintText "==>> git config --local alias.show-work elegant show-work"
+  , PrintText "==>> git config --local alias.show-workflows elegant show-workflows"
+  , PrintText "==>> git config --local alias.start-work elegant start-work"
+  ]
+
+signatureOutputBlock :: [GitCommand]
+signatureOutputBlock =
+  [ PrintText "=============================="
+  , PrintText "== Configuring signature... =="
+  , PrintText "=============================="
+  ]
+
+configuredStandards :: HashMap Text Text
+configuredStandards =
+  [ ("core.editor",                    "test")
+  , ("apply.whitespace",               "fix")
+  , ("fetch.pruneTags",                "false")
+  , ("core.autocrlf",                  "input")
+  , ("fetch.prune",                    "true")
+  , ("elegant-git.default-branch",     "test")
+  , ("user.email",                     "test")
+  , ("user.name",                      "test")
+  , ("pull.rebase",                    "true")
+  , ("rebase.autoStash",               "false")
+  , ("core.commentChar",               "|")
+  , ("credential.helper",              "osxkeychain")
+  , ("elegant-git.protected-branches", "test")
+  ]
+
+configuredAliases :: HashMap Text Text
+configuredAliases =
+  [ ("alias.accept-work",        "elegant accept-work")
+  , ("alias.acquire-git",        "elegant acquire-git")
+  , ("alias.acquire-repository", "elegant acquire-repository")
+  , ("alias.actualize-work",     "elegant actualize-work")
+  , ("alias.amend-work",         "elegant amend-work")
+  , ("alias.clone-repository",   "elegant clone-repository")
+  , ("alias.deliver-work",       "elegant deliver-work")
+  , ("alias.init-repository",    "elegant init-repository")
+  , ("alias.make-workflow",      "elegant make-workflow")
+  , ("alias.obtain-work",        "elegant obtain-work")
+  , ("alias.polish-work",        "elegant polish-work")
+  , ("alias.polish-workflow",    "elegant polish-workflow")
+  , ("alias.prune-repository",   "elegant prune-repository")
+  , ("alias.release-work",       "elegant release-work")
+  , ("alias.save-work",          "elegant save-work")
+  , ("alias.show-commands",      "elegant show-commands")
+  , ("alias.show-release-notes", "elegant show-release-notes")
+  , ("alias.show-work",          "elegant show-work")
+  , ("alias.show-workflows",     "elegant show-workflows")
+  , ("alias.start-work",         "elegant start-work")
+  ]
+
+spec :: Spec
+spec = do
+  describe "cmd" $ do
+    it "prepares local git repository for further work" $ do
+      let
+        repoWithNewConfig = defaultGit
+          & gRepository.grConfig %~ union
+            (configuredStandards `union` configuredAliases)
+
+      runGitActionPure defaultGit AcquireRepository.cmd `shouldBe`
+        ( repoWithNewConfig
+        , [ PrintText "========================================="
+          , PrintText "== Removing obsolete configurations... =="
+          , PrintText "========================================="
+          , PrintText "==========================="
+          , PrintText "== Configuring basics... =="
+          , PrintText "==========================="
+          , Prompt    "What is your user name?: test"
+          , PrintText "==>> git config --local user.name test"
+          , Prompt    "What is your email?: test"
+          , PrintText "==>> git config --local user.email test"
+          , Prompt    "What is the command to launching an editor?: test"
+          , PrintText "==>> git config --local core.editor test"
+          , Prompt    "What is the default branch? {master}: test"
+          , PrintText "==>> git config --local elegant-git.default-branch test"
+          , Prompt    "What are protected branches (split with space) {master}: test"
+          , PrintText "==>> git config --local elegant-git.protected-branches test"
+          ]
+         ++ standardsOutputBlock
+         ++ aliasesOutputBlock
+         ++ signatureOutputBlock
+        )
+
+    it "uses global config values as defaults for prompts" $ do
+      let
+        git = defaultGit
+          & gConfig %~ union
+            [ ("core.editor", "test-editor")
+            , ("user.email",  "test-email")
+            , ("user.name",   "test-name")
+            ]
+
+        repoWithNewConfig = git
+          & gRepository.grConfig %~ union
+            (configuredStandards `union` configuredAliases)
+
+      runGitActionPure git AcquireRepository.cmd `shouldBe`
+        ( repoWithNewConfig
+        , [ PrintText "========================================="
+          , PrintText "== Removing obsolete configurations... =="
+          , PrintText "========================================="
+          , PrintText "==========================="
+          , PrintText "== Configuring basics... =="
+          , PrintText "==========================="
+          , Prompt    "What is your user name? {test-name}: test"
+          , PrintText "==>> git config --local user.name test"
+          , Prompt    "What is your email? {test-email}: test"
+          , PrintText "==>> git config --local user.email test"
+          , Prompt    "What is the command to launching an editor? {test-editor}: test"
+          , PrintText "==>> git config --local core.editor test"
+          , Prompt    "What is the default branch? {master}: test"
+          , PrintText "==>> git config --local elegant-git.default-branch test"
+          , Prompt    "What are protected branches (split with space) {master}: test"
+          , PrintText "==>> git config --local elegant-git.protected-branches test"
+          ]
+         ++ standardsOutputBlock
+         ++ aliasesOutputBlock
+         ++ signatureOutputBlock
+        )
+
+    it "does not alter unexpected config" $ do
+      let
+        git = defaultGit
+          & gRepository.grConfig %~ union
+            [ ("test.test",  "test")
+            ]
+
+        repoWithNewConfig = git
+          & gRepository.grConfig %~ union
+            (configuredStandards `union` configuredAliases)
+
+      runGitActionPure git AcquireRepository.cmd `shouldBe`
+        ( repoWithNewConfig
+        , [ PrintText "========================================="
+          , PrintText "== Removing obsolete configurations... =="
+          , PrintText "========================================="
+          , PrintText "==========================="
+          , PrintText "== Configuring basics... =="
+          , PrintText "==========================="
+          , Prompt    "What is your user name?: test"
+          , PrintText "==>> git config --local user.name test"
+          , Prompt    "What is your email?: test"
+          , PrintText "==>> git config --local user.email test"
+          , Prompt    "What is the command to launching an editor?: test"
+          , PrintText "==>> git config --local core.editor test"
+          , Prompt    "What is the default branch? {master}: test"
+          , PrintText "==>> git config --local elegant-git.default-branch test"
+          , Prompt    "What are protected branches (split with space) {master}: test"
+          , PrintText "==>> git config --local elegant-git.protected-branches test"
+          ]
+         ++ standardsOutputBlock
+         ++ aliasesOutputBlock
+         ++ signatureOutputBlock
+        )
+
+    it "removes obsolete configuration" $ do
+      let
+        git = defaultGit
+          & gRepository.grConfig %~ union
+            [ ("elegant.acquired",  "true")
+            ]
+
+        repoWithNewConfig = git
+          & gRepository.grConfig %~
+            delete "elegant.acquired"
+          & gRepository.grConfig %~ union
+            (configuredStandards `union` configuredAliases)
+
+      runGitActionPure git AcquireRepository.cmd `shouldBe`
+        ( repoWithNewConfig
+        , [ PrintText "========================================="
+          , PrintText "== Removing obsolete configurations... =="
+          , PrintText "========================================="
+          , PrintText "Removing old Elegnat Git configuration keys..."
+          , PrintText "==>> git config --local --unset elegant.acquired"
+          , PrintText "==========================="
+          , PrintText "== Configuring basics... =="
+          , PrintText "==========================="
+          , Prompt    "What is your user name?: test"
+          , PrintText "==>> git config --local user.name test"
+          , Prompt    "What is your email?: test"
+          , PrintText "==>> git config --local user.email test"
+          , Prompt    "What is the command to launching an editor?: test"
+          , PrintText "==>> git config --local core.editor test"
+          , Prompt    "What is the default branch? {master}: test"
+          , PrintText "==>> git config --local elegant-git.default-branch test"
+          , Prompt    "What are protected branches (split with space) {master}: test"
+          , PrintText "==>> git config --local elegant-git.protected-branches test"
+          ]
+         ++ standardsOutputBlock
+         ++ aliasesOutputBlock
+         ++ signatureOutputBlock
+        )
+
+    it "removes old aliases" $ do
+      let
+        git = defaultGit
+          & gRepository.grConfig %~ union
+          [ ("alias.polish-work",        "elegant polish-work")
+          , ("alias.polish-workflow",    "elegant polish-workflow")
+          , ("alias.prune-repository",   "elegant prune-repository")
+          ]
+
+        repoWithNewConfig = git
+          & gRepository.grConfig %~ union
+            (configuredStandards `union` configuredAliases)
+
+      runGitActionPure git AcquireRepository.cmd `shouldBe`
+        ( repoWithNewConfig
+        , [ PrintText "========================================="
+          , PrintText "== Removing obsolete configurations... =="
+          , PrintText "========================================="
+          , PrintText "Removing old Elegant Git aliases..."
+          , PrintText "==>> git config --local --unset alias.polish-work"
+          , PrintText "==>> git config --local --unset alias.polish-workflow"
+          , PrintText "==>> git config --local --unset alias.prune-repository"
+          , PrintText "==========================="
+          , PrintText "== Configuring basics... =="
+          , PrintText "==========================="
+          , Prompt    "What is your user name?: test"
+          , PrintText "==>> git config --local user.name test"
+          , Prompt    "What is your email?: test"
+          , PrintText "==>> git config --local user.email test"
+          , Prompt    "What is the command to launching an editor?: test"
+          , PrintText "==>> git config --local core.editor test"
+          , Prompt    "What is the default branch? {master}: test"
+          , PrintText "==>> git config --local elegant-git.default-branch test"
+          , Prompt    "What are protected branches (split with space) {master}: test"
+          , PrintText "==>> git config --local elegant-git.protected-branches test"
+          ]
+         ++ standardsOutputBlock
+         ++ aliasesOutputBlock
+         ++ signatureOutputBlock
+        )

--- a/test/Elegit/Cli/Parser/AcquireRepositorySpec.hs
+++ b/test/Elegit/Cli/Parser/AcquireRepositorySpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Elegit.Cli.Parser.AcquireRepositorySpec where
+
+import           Data.String.QQ
+import           Elegit.Cli.Command     (ElegitCommand (..))
+import           Elegit.Cli.Parser.Util as P
+import           Test.Hspec
+import           Universum
+
+
+helpText :: Text
+helpText = "Usage: git elegant acquire-repository \n" <> [s|
+
+  Configures the current local Git repository.
+
+Available options:
+  -h,--help                Show this help text
+
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using `git config --local`. The command asks to
+provide information that is needed for the current repository configuration.
+
+The behavior of the command varies depend on `git elegant acquire-git`
+execution (a global configuration). If the global configuration is applied,
+then this command configures repository-related staffs only, otherwise, it
+applies all configurations to the current local repository.
+
+To find out what will be configured, please visit
+placeholder/en/latest/configuration/|]
+
+invalidArgumentHelp :: Text
+invalidArgumentHelp = [s|
+Invalid argument `test-arg'
+
+|] <> "Usage: git elegant acquire-repository \n" <> [s|
+
+  Configures the current local Git repository.
+
+Available options:
+  -h,--help                Show this help text
+
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using `git config --local`. The command asks to
+provide information that is needed for the current repository configuration.
+
+The behavior of the command varies depend on `git elegant acquire-git`
+execution (a global configuration). If the global configuration is applied,
+then this command configures repository-related staffs only, otherwise, it
+applies all configurations to the current local repository.
+
+To find out what will be configured, please visit
+placeholder/en/latest/configuration/|]
+
+invalidOptionHelp :: Text
+invalidOptionHelp = [s|
+Invalid option `--test-arg'
+
+|] <> "Usage: git elegant acquire-repository \n" <> [s|
+
+  Configures the current local Git repository.
+
+Available options:
+  -h,--help                Show this help text
+
+Applies the "basics", "standards", "aliases", and "signature" configurations
+to the current Git repository using `git config --local`. The command asks to
+provide information that is needed for the current repository configuration.
+
+The behavior of the command varies depend on `git elegant acquire-git`
+execution (a global configuration). If the global configuration is applied,
+then this command configures repository-related staffs only, otherwise, it
+applies all configurations to the current local repository.
+
+To find out what will be configured, please visit
+placeholder/en/latest/configuration/|]
+
+spec :: Spec
+spec = do
+  describe "cmd" $ do
+    it "parses command succefully" $ do
+      parseMaybe "acquire-repository" [] `shouldBe` Just AcquireRepositoryCommand
+
+    it "renders command help" $ do
+      parseResult "acquire-repository" ["--help"] `shouldRender` helpText
+
+    it "failes to parse unexpected arguments" $ do
+      parseResult "acquire-repository" ["test-arg"] `shouldRender` invalidArgumentHelp
+
+    it "failes to parse unexpected options" $ do
+      parseResult "acquire-repository" ["--test-arg"] `shouldRender` invalidOptionHelp


### PR DESCRIPTION
Port `git-elegant-acquire-repository` command to haskell.

#297

The contribution:
- [ ] updates all affected documentation
- [ ] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [ ] updates the completion scripts if requires
- [ ] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
