### PR TITLE
Improve testability of the `Real` interpreter

### DIFF
--- a/.github/workflows/haskell-quality-pipeline.yml
+++ b/.github/workflows/haskell-quality-pipeline.yml
@@ -28,19 +28,21 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
       name: Cache .ghcup
+      id: haskell-env-cache
       with:
         path: ~/.ghcup
         key: ${{ runner.os }}-ghcup-global-${{ env.GHCUP_VERSION }}-${{ env.STACK_VERSION }}
         restore-keys: |
-          ${{ runner.os }}-ghcup-global-${{ env.GHCUP_VERSION }}
+          ${{ runner.os }}-ghcup-global-${{ env.GHCUP_VERSION }}-
           ${{ runner.os }}-ghcup-global-
     - uses: actions/cache@v3
       name: Cache .stack
+      id: haskell-deps-cache
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack-global-${{ env.GHC_VERSION }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+        key: ${{ runner.os }}-stack-global-${{ env.GHC_VERSION }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-stack-global-${{ env.GHC_VERSION }}
+          ${{ runner.os }}-stack-global-${{ env.GHC_VERSION }}-
     - name: Setup haskell enviroment
       run: |
         export PATH=~/.ghcup/bin:$PATH

--- a/elegant-git.cabal
+++ b/elegant-git.cabal
@@ -30,6 +30,7 @@ library
       Elegit.Cli.Command
       Elegit.Cli.Parser
       Elegit.Git.Action
+      Elegit.Git.Exec
       Elegit.Git.Runner.Real
       Elegit.Git.Runner.Simulated
       Lib
@@ -46,6 +47,7 @@ library
       base >=4.7 && <5
     , containers
     , dlist
+    , exceptions
     , fmt
     , free
     , microlens
@@ -79,6 +81,7 @@ executable git-elegant
     , containers
     , dlist
     , elegant-git
+    , exceptions
     , fmt
     , free
     , microlens
@@ -119,6 +122,7 @@ test-suite elegant-git-test
     , containers
     , dlist
     , elegant-git
+    , exceptions
     , fmt
     , free
     , hspec

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 
 - universum
 - string-qq
+- exceptions
 - text
 - safe-exceptions
 - fmt

--- a/src/Elegit/Git/Exec.hs
+++ b/src/Elegit/Git/Exec.hs
@@ -1,0 +1,116 @@
+module Elegit.Git.Exec where
+
+import           Control.Monad.Catch  as MC
+import           Data.Text            (stripEnd)
+import           Elegit.Git.Action
+import           Fmt
+import           GHC.IO.Handle        (hFlush)
+import           System.Process.Typed (ExitCode (ExitFailure, ExitSuccess), proc, readProcess)
+import           Universum
+
+
+newtype GitExecT m a
+  = GitExecT { runGitExecT :: m a }
+
+-- TODO: Improve code usability by creating a generic type-class which should have instance
+-- for every possible command.
+data GitCommand
+  = GCCB GCurrentBranchData
+  | GCBU GBranchUpstreamData
+  | GCL GLogData
+  | GCS GStatusData
+  | GCSL GStashListData
+  | GCRC GReadConfigData
+  | GCSC GSetConfigData
+  | GCUC GUnsetConfigData
+  | GCATR GAliasesToRemoveData
+
+
+-- TODO: cover with tests
+renderGitCommand :: GitCommand -> Text
+renderGitCommand (GCCB gc)  = renderGC gc
+renderGitCommand (GCBU gc)  = renderGC gc
+renderGitCommand (GCL gc)   = "-c color.ui=always "+|renderGC gc|+""
+renderGitCommand (GCS gc)   = "-c color.status=always "+|renderGC gc|+""
+renderGitCommand (GCSL gc)  = renderGC gc
+renderGitCommand (GCRC gc)  = renderGC gc
+renderGitCommand (GCSC gc)  = renderGC gc
+renderGitCommand (GCUC gc)  = renderGC gc
+renderGitCommand (GCATR gc) = renderGC gc
+
+
+class Monad m => MonadGitExec m where
+  execGit :: GitCommand -> m (Maybe Text)
+  pText :: Text -> m ()
+  pTextLn :: Text -> m ()
+  gLine :: m Text
+
+instance MonadIO m => MonadGitExec (GitExecT m) where
+  execGit gc = do
+    (eCode, outputBS, _errBS) <- readProcess $ proc "git" (toString <$> words (renderGitCommand gc))
+    case eCode of
+      -- TODO: Handle error codes per `gc`
+      ExitFailure _ -> do
+        return Nothing
+      ExitSuccess -> do
+        let output = stripEnd $ decodeUtf8 outputBS
+        return $ if null output then Nothing else Just output
+
+  pText t = do
+    putText t
+    liftIO $ hFlush stdout
+  pTextLn = putTextLn
+  gLine = getLine
+
+{- This is the boilerplate required by mtl to define custom monad transformer
+ - Theoretically, mtl is the fastest library. However, it's too generic which results
+ - in a huge amount of boilerplate, which is not ideal. This is also, not a full list type-classes
+ - we need to support. However, for now, this is enough.
+ - There are some more drawbacks to mtl, but they are not relevant yet.
+
+ - There are many alternatives to mtl, e.g. `fused-effects` or `polisemy`, and in theory it could be better
+ - to start using them instead of mtl. Custom effects are much easier to define, and don't require to
+ - support every new transformer in the stack.
+ -}
+
+liftGitExecT :: m a -> GitExecT m a
+liftGitExecT = GitExecT
+{-# INLINE liftGitExecT #-}
+
+mapReaderT :: (m a -> n b) -> GitExecT m a -> GitExecT n b
+mapReaderT f m = GitExecT $ f $ runGitExecT m
+{-# INLINE mapReaderT #-}
+
+instance Functor m => Functor (GitExecT m) where
+  fmap f = mapReaderT (fmap f)
+  {-# INLINE fmap #-}
+
+instance Applicative m => Applicative (GitExecT m) where
+  pure = liftGitExecT . pure
+  {-# INLINE pure #-}
+  f <*> v = GitExecT $ runGitExecT f <*> runGitExecT v
+  {-# INLINE (<*>) #-}
+
+instance Monad m => Monad (GitExecT m) where
+  return = pure
+  {-# INLINE return #-}
+  m >>= f = GitExecT $ do
+    a <- runGitExecT m
+    runGitExecT (f a)
+  {-# INLINE (>>=) #-}
+
+instance MonadTrans GitExecT where
+  lift = liftGitExecT
+  {-# INLINE lift #-}
+
+instance MonadThrow m => MonadThrow (GitExecT m) where
+  throwM e = lift $ MC.throwM e
+  {-# INLINE throwM #-}
+
+instance MonadCatch m => MonadCatch (GitExecT m) where
+  catch (GitExecT m) c = GitExecT $ m `MC.catch` \e -> runGitExecT (c e)
+  {-# INLINE catch #-}
+
+instance (MonadIO m) => MonadIO (GitExecT m) where
+  liftIO = liftGitExecT . liftIO
+  {-# INLINE liftIO #-}

--- a/src/Elegit/Git/Exec.hs
+++ b/src/Elegit/Git/Exec.hs
@@ -3,7 +3,6 @@ module Elegit.Git.Exec where
 import           Control.Monad.Catch  as MC
 import           Data.Text            (stripEnd)
 import           Elegit.Git.Action
-import           Fmt
 import           GHC.IO.Handle        (hFlush)
 import           System.Process.Typed (ExitCode (ExitFailure, ExitSuccess), proc, readProcess)
 import           Universum
@@ -27,16 +26,16 @@ data GitCommand
 
 
 -- TODO: cover with tests
-renderGitCommand :: GitCommand -> Text
-renderGitCommand (GCCB gc)  = renderGC gc
-renderGitCommand (GCBU gc)  = renderGC gc
-renderGitCommand (GCL gc)   = "-c color.ui=always "+|renderGC gc|+""
-renderGitCommand (GCS gc)   = "-c color.status=always "+|renderGC gc|+""
-renderGitCommand (GCSL gc)  = renderGC gc
-renderGitCommand (GCRC gc)  = renderGC gc
-renderGitCommand (GCSC gc)  = renderGC gc
-renderGitCommand (GCUC gc)  = renderGC gc
-renderGitCommand (GCATR gc) = renderGC gc
+gitCommandArgs :: GitCommand -> [Text]
+gitCommandArgs (GCCB gc)  = commandArgs gc
+gitCommandArgs (GCBU gc)  = commandArgs gc
+gitCommandArgs (GCL gc)   = "-c":"color.ui=always":commandArgs gc
+gitCommandArgs (GCS gc)   = "-c":"color.status=always":commandArgs gc
+gitCommandArgs (GCSL gc)  = commandArgs gc
+gitCommandArgs (GCRC gc)  = commandArgs gc
+gitCommandArgs (GCSC gc)  = commandArgs gc
+gitCommandArgs (GCUC gc)  = commandArgs gc
+gitCommandArgs (GCATR gc) = commandArgs gc
 
 
 class Monad m => MonadGitExec m where
@@ -47,7 +46,7 @@ class Monad m => MonadGitExec m where
 
 instance MonadIO m => MonadGitExec (GitExecT m) where
   execGit gc = do
-    (eCode, outputBS, _errBS) <- readProcess $ proc "git" (toString <$> words (renderGitCommand gc))
+    (eCode, outputBS, _errBS) <- readProcess $ proc "git" (toString <$> gitCommandArgs gc)
     case eCode of
       -- TODO: Handle error codes per `gc`
       ExitFailure _ -> do

--- a/src/Elegit/Git/Runner/Real.hs
+++ b/src/Elegit/Git/Runner/Real.hs
@@ -3,12 +3,89 @@ module Elegit.Git.Runner.Real where
 import           Control.Exception.Safe    (throwString)
 import           Control.Monad.Free.Church
 import           Control.Monad.HT
-import           Data.Text                 (stripEnd)
 import qualified Elegit.Git.Action         as GA
+import           Elegit.Git.Exec           (GitCommand (..), MonadGitExec (execGit, gLine, pText, pTextLn))
 import           Fmt
-import           System.IO                 (hFlush)
-import           System.Process.Typed      (ExitCode (ExitFailure, ExitSuccess), proc, readProcess)
 import           Universum                 as U
+
+
+-- | Execute the action in the real world.
+executeGit :: (MonadCatch m, MonadGitExec m) => GA.FreeGit () -> m ()
+executeGit = foldF executeGitF
+
+
+-- | Interpreter for the real world
+--
+-- Currently just prints the resulting commands without any execution.
+--
+executeGitF :: (MonadCatch m, MonadGitExec m) => GA.GitF a -> m a
+executeGitF arg = case arg of
+  GA.CurrentBranch gc next -> do
+    mCurrentBranch <- execGit (GCCB gc)
+    case mCurrentBranch of
+      Nothing -> throwString "No branch found. Seems like this repository was not initialized fully."
+      Just currentBranch ->
+        return $ next currentBranch
+
+  GA.BranchUpstream gc next -> do
+    mUpstreamBranch <- execGit (GCBU gc)
+    return $ next mUpstreamBranch
+
+  GA.Log gc next -> do
+    logs <- lines . fromMaybe "" <$> execGit (GCL gc)
+    return $ next logs
+  GA.Status gc next -> do
+    changes <- lines . fromMaybe "" <$> execGit (GCS gc)
+    return $ next changes
+  GA.StashList gc next -> do
+    stashes <- lines . fromMaybe "" <$> execGit (GCSL gc)
+    return $ next stashes
+
+  GA.AliasesToRemove gc next -> do
+    oldAliasesM <- execGit (GCATR gc)
+    return $ next (oldAliasesM >>= nonEmpty . lines)
+  GA.ReadConfig gc next -> do
+    next <$> execGit (GCRC gc)
+  GA.SetConfig gc next -> do
+    U.void $ execGit (GCSC gc)
+    return next
+  GA.UnsetConfig gc next -> do
+    U.void $ execGit (GCUC gc)
+    return next
+  GA.Prompt prompt pDefaultM next -> do
+    let
+      askPrompt = do
+        pText (colored Purple Normal message)
+        gLine
+
+      message :: Text
+      message =
+        case pDefaultM of
+          Just pDefault -> fmt ""+|prompt|+" {"+|pDefault|+"}: "
+          Nothing       -> fmt ""+|prompt|+": "
+
+    answer <-
+      case pDefaultM of
+        Nothing -> until (not . null) askPrompt
+        Just pDefault -> do
+          answer <- askPrompt
+          if null answer
+             then return pDefault
+             else return answer
+    return $ next answer
+
+  GA.FormatInfo content next -> do
+    return $ next $ colored Green Normal content
+  GA.FormatCommand content next -> do
+    return $ next $ colored Green Normal "==>>" <> " " <> colored Blue Bold content
+
+  GA.PrintText content next -> do
+    pTextLn content
+    return next
+
+colored :: Color -> FontStyle -> Text -> Text
+colored color style content =
+  fmt "\x1b["+||fontStyleCode style||+";"+||colorCode color||+"m"+|content|+"\x1b[0m"
 
 
 data Color
@@ -29,129 +106,3 @@ data FontStyle
 fontStyleCode :: FontStyle -> Int
 fontStyleCode Normal = 0
 fontStyleCode Bold   = 1
-
-
-runGit :: (MonadIO m) => Text -> m (Maybe Text)
-runGit cmd = do
-    (eCode, outputBS, _errBS) <- readProcess $ proc "git" (toString <$> words cmd)
-    case eCode of
-      ExitFailure _ -> do
-          -- TODO: Know what error is expected and log unexpected ones.
-          return Nothing
-      ExitSuccess -> do
-          let output = stripEnd $ decodeUtf8 outputBS
-          return $ if null output then Nothing else Just output
-
--- | Execute the action in the real world.
-executeGit :: (MonadCatch m, MonadIO m) => GA.FreeGit () -> m ()
-executeGit = foldF executeGitF
-
-
-colored :: Color -> FontStyle -> Text -> Text
-colored color style content =
-    fmt "\x1b["+||fontStyleCode style||+";"+||colorCode color||+"m"+|content|+"\x1b[0m"
-
--- | Interpreter for the real world
---
--- Currently just prints the resulting commands without any execution.
---
-executeGitF :: (MonadCatch m, MonadIO m) => GA.GitF a -> m a
-executeGitF arg = case arg of
-    GA.CurrentBranch next -> do
-        mCurrentBranch <- runGit "rev-parse --abbrev-ref @"
-        case mCurrentBranch of
-          Nothing -> throwString "No branch found. Seems like this repository was not initialized fully."
-          Just currentBranch ->
-            return $ next currentBranch
-
-    GA.BranchUpstream branch next -> do
-        mUpstreamBranch <- runGit (fmt "rev-parse --abbrev-ref "+|branch|+"@{upstream}")
-        return $ next mUpstreamBranch
-
-    GA.Log lType base target next -> do
-        let
-            logArg :: Text
-            logArg = case lType of
-                       GA.LogOneLine -> "--oneline"
-
-        logs <- lines . fromMaybe "" <$> runGit (fmt "-c color.ui=always log "+|logArg|+" "+|base|+".."+|target|+"")
-        return $ next logs
-    GA.Status sType next -> do
-        let
-            statusFormat :: Text
-            statusFormat = case sType of
-                             GA.StatusShort -> "--short"
-
-        changes <- lines . fromMaybe "" <$> runGit (fmt "-c color.status=always status "+|statusFormat|+"")
-        return $ next changes
-    GA.StashList next -> do
-        stashes <- lines . fromMaybe "" <$> runGit "stash list"
-        return $ next stashes
-
-    GA.AliasesToRemove cScope next -> do
-        let
-            scope :: Text
-            scope = case cScope of
-                      GA.LocalConfig  -> "--local"
-                      GA.GlobalConfig -> "--global"
-                      GA.AutoConfig   -> ""
-
-        oldAliasesM <- runGit (fmt "config "+|scope|+" --name-only --get-regexp \"^alias.\" \"^elegant ([-a-z]+)$\"")
-        return $ next (oldAliasesM >>= nonEmpty . lines)
-    GA.ReadConfig cScope cName next -> do
-        let
-            scope :: Text
-            scope = case cScope of
-                      GA.LocalConfig  -> "--local"
-                      GA.GlobalConfig -> "--global"
-                      GA.AutoConfig   -> ""
-
-        next <$> runGit (fmt "config "+|scope|+" --get "+|cName|+"")
-    GA.SetConfig cScope cName cValue next -> do
-        let
-            scope :: Text
-            scope = case cScope of
-                      GA.LocalConfig  -> "--local"
-                      GA.AutoConfig   -> "--local"
-                      GA.GlobalConfig -> "--global"
-        U.void $ runGit (fmt "config "+|scope|+" "+|cName|+" "+|cValue|+"")
-        return next
-    GA.UnsetConfig cScope cName next -> do
-        let
-            scope :: Text
-            scope = case cScope of
-                      GA.LocalConfig  -> "--local"
-                      GA.AutoConfig   -> "--local"
-                      GA.GlobalConfig -> "--global"
-        U.void $ runGit (fmt "config "+|scope|+" --unset "+|cName|+"")
-        return next
-    GA.Prompt prompt pDefaultM next -> do
-        let
-            askPrompt = do
-                putText (colored Purple Normal message)
-                liftIO $ hFlush stdout
-                getLine
-
-            message :: Text
-            message =
-                case pDefaultM of
-                  Just pDefault -> fmt ""+|prompt|+" {"+|pDefault|+"}: "
-                  Nothing       -> fmt ""+|prompt|+": "
-
-        answer <- case pDefaultM of
-              Nothing -> until (not . null) askPrompt
-              Just pDefault -> do
-                  answer <- askPrompt
-                  if null answer
-                     then return pDefault
-                     else return answer
-        return $ next answer
-
-    GA.FormatInfo content next -> do
-        return $ next $ colored Green Normal content
-    GA.FormatCommand content next -> do
-        return $ next $ colored Green Normal "==>>" <> " " <> colored Blue Bold content
-
-    GA.PrintText content next -> do
-        putTextLn content
-        return next

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -4,6 +4,7 @@ import qualified Elegit.Cli.Action.AcquireRepository as AcquireRepository
 import qualified Elegit.Cli.Action.ShowWork          as ShowWork
 import           Elegit.Cli.Command                  (ElegitCommand (..))
 import qualified Elegit.Cli.Parser                   as P
+import           Elegit.Git.Exec                     (GitExecT (runGitExecT))
 import           Elegit.Git.Runner.Real              (executeGit)
 import           Options.Applicative                 (customExecParser)
 import           Universum
@@ -13,6 +14,7 @@ runCli = do
   cmd <- liftIO $ customExecParser P.cliPrefs P.cli
 
   flip catch (\e -> putTextLn $ "Caught exception: " <> show (e :: SomeException) ) $
+    runGitExecT $
     executeGit $
       case cmd of
          ShowWorkCommand          -> ShowWork.cmd

--- a/test/Elegit/Cli/Action/AcquireRepositorySpec.hs
+++ b/test/Elegit/Cli/Action/AcquireRepositorySpec.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes     #-}
 module Elegit.Cli.Action.AcquireRepositorySpec where
 
 import           Data.HashMap.Strict                 (delete, union)
+import           Data.String.QQ
 import qualified Elegit.Cli.Action.AcquireRepository as AcquireRepository
 import           Elegit.Git.Runner.Simulated
 import           Lens.Micro
@@ -42,44 +44,44 @@ defaultGit =
 
 standardsOutputBlock :: [GitCommand]
 standardsOutputBlock =
-  [ PrintText "=============================="
-  , PrintText "== Configuring standards... =="
-  , PrintText "=============================="
-  , PrintText "==>> git config --local core.commentChar |"
-  , PrintText "==>> git config --local apply.whitespace fix"
-  , PrintText "==>> git config --local fetch.prune true"
-  , PrintText "==>> git config --local fetch.pruneTags false"
-  , PrintText "==>> git config --local core.autocrlf input"
-  , PrintText "==>> git config --local pull.rebase true"
-  , PrintText "==>> git config --local rebase.autoStash false"
-  , PrintText "==>> git config --local credential.helper osxkeychain"
+  [ PrintText [s|==============================|]
+  , PrintText [s|== Configuring standards... ==|]
+  , PrintText [s|==============================|]
+  , PrintText [s|==>> git config --local core.commentChar "|"|]
+  , PrintText [s|==>> git config --local apply.whitespace "fix"|]
+  , PrintText [s|==>> git config --local fetch.prune "true"|]
+  , PrintText [s|==>> git config --local fetch.pruneTags "false"|]
+  , PrintText [s|==>> git config --local core.autocrlf "input"|]
+  , PrintText [s|==>> git config --local pull.rebase "true"|]
+  , PrintText [s|==>> git config --local rebase.autoStash "false"|]
+  , PrintText [s|==>> git config --local credential.helper "osxkeychain"|]
   ]
 
 aliasesOutputBlock :: [GitCommand]
 aliasesOutputBlock =
-  [ PrintText "============================"
-  , PrintText "== Configuring aliases... =="
-  , PrintText "============================"
-  , PrintText "==>> git config --local alias.accept-work elegant accept-work"
-  , PrintText "==>> git config --local alias.acquire-git elegant acquire-git"
-  , PrintText "==>> git config --local alias.acquire-repository elegant acquire-repository"
-  , PrintText "==>> git config --local alias.actualize-work elegant actualize-work"
-  , PrintText "==>> git config --local alias.amend-work elegant amend-work"
-  , PrintText "==>> git config --local alias.clone-repository elegant clone-repository"
-  , PrintText "==>> git config --local alias.deliver-work elegant deliver-work"
-  , PrintText "==>> git config --local alias.init-repository elegant init-repository"
-  , PrintText "==>> git config --local alias.make-workflow elegant make-workflow"
-  , PrintText "==>> git config --local alias.obtain-work elegant obtain-work"
-  , PrintText "==>> git config --local alias.polish-work elegant polish-work"
-  , PrintText "==>> git config --local alias.polish-workflow elegant polish-workflow"
-  , PrintText "==>> git config --local alias.prune-repository elegant prune-repository"
-  , PrintText "==>> git config --local alias.release-work elegant release-work"
-  , PrintText "==>> git config --local alias.save-work elegant save-work"
-  , PrintText "==>> git config --local alias.show-commands elegant show-commands"
-  , PrintText "==>> git config --local alias.show-release-notes elegant show-release-notes"
-  , PrintText "==>> git config --local alias.show-work elegant show-work"
-  , PrintText "==>> git config --local alias.show-workflows elegant show-workflows"
-  , PrintText "==>> git config --local alias.start-work elegant start-work"
+  [ PrintText [s|============================|]
+  , PrintText [s|== Configuring aliases... ==|]
+  , PrintText [s|============================|]
+  , PrintText [s|==>> git config --local alias.accept-work "elegant accept-work"|]
+  , PrintText [s|==>> git config --local alias.acquire-git "elegant acquire-git"|]
+  , PrintText [s|==>> git config --local alias.acquire-repository "elegant acquire-repository"|]
+  , PrintText [s|==>> git config --local alias.actualize-work "elegant actualize-work"|]
+  , PrintText [s|==>> git config --local alias.amend-work "elegant amend-work"|]
+  , PrintText [s|==>> git config --local alias.clone-repository "elegant clone-repository"|]
+  , PrintText [s|==>> git config --local alias.deliver-work "elegant deliver-work"|]
+  , PrintText [s|==>> git config --local alias.init-repository "elegant init-repository"|]
+  , PrintText [s|==>> git config --local alias.make-workflow "elegant make-workflow"|]
+  , PrintText [s|==>> git config --local alias.obtain-work "elegant obtain-work"|]
+  , PrintText [s|==>> git config --local alias.polish-work "elegant polish-work"|]
+  , PrintText [s|==>> git config --local alias.polish-workflow "elegant polish-workflow"|]
+  , PrintText [s|==>> git config --local alias.prune-repository "elegant prune-repository"|]
+  , PrintText [s|==>> git config --local alias.release-work "elegant release-work"|]
+  , PrintText [s|==>> git config --local alias.save-work "elegant save-work"|]
+  , PrintText [s|==>> git config --local alias.show-commands "elegant show-commands"|]
+  , PrintText [s|==>> git config --local alias.show-release-notes "elegant show-release-notes"|]
+  , PrintText [s|==>> git config --local alias.show-work "elegant show-work"|]
+  , PrintText [s|==>> git config --local alias.show-workflows "elegant show-workflows"|]
+  , PrintText [s|==>> git config --local alias.start-work "elegant start-work"|]
   ]
 
 signatureOutputBlock :: [GitCommand]
@@ -141,22 +143,22 @@ spec = do
 
       runGitActionPure defaultGit AcquireRepository.cmd `shouldBe`
         ( repoWithNewConfig
-        , [ PrintText "========================================="
-          , PrintText "== Removing obsolete configurations... =="
-          , PrintText "========================================="
-          , PrintText "==========================="
-          , PrintText "== Configuring basics... =="
-          , PrintText "==========================="
-          , Prompt    "What is your user name?: test"
-          , PrintText "==>> git config --local user.name test"
-          , Prompt    "What is your email?: test"
-          , PrintText "==>> git config --local user.email test"
-          , Prompt    "What is the command to launching an editor?: test"
-          , PrintText "==>> git config --local core.editor test"
-          , Prompt    "What is the default branch? {master}: test"
-          , PrintText "==>> git config --local elegant-git.default-branch test"
-          , Prompt    "What are protected branches (split with space) {master}: test"
-          , PrintText "==>> git config --local elegant-git.protected-branches test"
+        , [ PrintText [s|=========================================|]
+          , PrintText [s|== Removing obsolete configurations... ==|]
+          , PrintText [s|=========================================|]
+          , PrintText [s|===========================|]
+          , PrintText [s|== Configuring basics... ==|]
+          , PrintText [s|===========================|]
+          , Prompt    [s|What is your user name?: test|]
+          , PrintText [s|==>> git config --local user.name "test"|]
+          , Prompt    [s|What is your email?: test|]
+          , PrintText [s|==>> git config --local user.email "test"|]
+          , Prompt    [s|What is the command to launching an editor?: test|]
+          , PrintText [s|==>> git config --local core.editor "test"|]
+          , Prompt    [s|What is the default branch? {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.default-branch "test"|]
+          , Prompt    [s|What are protected branches (split with space) {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.protected-branches "test"|]
           ]
          ++ standardsOutputBlock
          ++ aliasesOutputBlock
@@ -178,22 +180,22 @@ spec = do
 
       runGitActionPure git AcquireRepository.cmd `shouldBe`
         ( repoWithNewConfig
-        , [ PrintText "========================================="
-          , PrintText "== Removing obsolete configurations... =="
-          , PrintText "========================================="
-          , PrintText "==========================="
-          , PrintText "== Configuring basics... =="
-          , PrintText "==========================="
-          , Prompt    "What is your user name? {test-name}: test"
-          , PrintText "==>> git config --local user.name test"
-          , Prompt    "What is your email? {test-email}: test"
-          , PrintText "==>> git config --local user.email test"
-          , Prompt    "What is the command to launching an editor? {test-editor}: test"
-          , PrintText "==>> git config --local core.editor test"
-          , Prompt    "What is the default branch? {master}: test"
-          , PrintText "==>> git config --local elegant-git.default-branch test"
-          , Prompt    "What are protected branches (split with space) {master}: test"
-          , PrintText "==>> git config --local elegant-git.protected-branches test"
+        , [ PrintText [s|=========================================|]
+          , PrintText [s|== Removing obsolete configurations... ==|]
+          , PrintText [s|=========================================|]
+          , PrintText [s|===========================|]
+          , PrintText [s|== Configuring basics... ==|]
+          , PrintText [s|===========================|]
+          , Prompt    [s|What is your user name? {test-name}: test|]
+          , PrintText [s|==>> git config --local user.name "test"|]
+          , Prompt    [s|What is your email? {test-email}: test|]
+          , PrintText [s|==>> git config --local user.email "test"|]
+          , Prompt    [s|What is the command to launching an editor? {test-editor}: test|]
+          , PrintText [s|==>> git config --local core.editor "test"|]
+          , Prompt    [s|What is the default branch? {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.default-branch "test"|]
+          , Prompt    [s|What are protected branches (split with space) {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.protected-branches "test"|]
           ]
          ++ standardsOutputBlock
          ++ aliasesOutputBlock
@@ -213,22 +215,22 @@ spec = do
 
       runGitActionPure git AcquireRepository.cmd `shouldBe`
         ( repoWithNewConfig
-        , [ PrintText "========================================="
-          , PrintText "== Removing obsolete configurations... =="
-          , PrintText "========================================="
-          , PrintText "==========================="
-          , PrintText "== Configuring basics... =="
-          , PrintText "==========================="
-          , Prompt    "What is your user name?: test"
-          , PrintText "==>> git config --local user.name test"
-          , Prompt    "What is your email?: test"
-          , PrintText "==>> git config --local user.email test"
-          , Prompt    "What is the command to launching an editor?: test"
-          , PrintText "==>> git config --local core.editor test"
-          , Prompt    "What is the default branch? {master}: test"
-          , PrintText "==>> git config --local elegant-git.default-branch test"
-          , Prompt    "What are protected branches (split with space) {master}: test"
-          , PrintText "==>> git config --local elegant-git.protected-branches test"
+        , [ PrintText [s|=========================================|]
+          , PrintText [s|== Removing obsolete configurations... ==|]
+          , PrintText [s|=========================================|]
+          , PrintText [s|===========================|]
+          , PrintText [s|== Configuring basics... ==|]
+          , PrintText [s|===========================|]
+          , Prompt    [s|What is your user name?: test|]
+          , PrintText [s|==>> git config --local user.name "test"|]
+          , Prompt    [s|What is your email?: test|]
+          , PrintText [s|==>> git config --local user.email "test"|]
+          , Prompt    [s|What is the command to launching an editor?: test|]
+          , PrintText [s|==>> git config --local core.editor "test"|]
+          , Prompt    [s|What is the default branch? {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.default-branch "test"|]
+          , Prompt    [s|What are protected branches (split with space) {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.protected-branches "test"|]
           ]
          ++ standardsOutputBlock
          ++ aliasesOutputBlock
@@ -250,24 +252,24 @@ spec = do
 
       runGitActionPure git AcquireRepository.cmd `shouldBe`
         ( repoWithNewConfig
-        , [ PrintText "========================================="
-          , PrintText "== Removing obsolete configurations... =="
-          , PrintText "========================================="
-          , PrintText "Removing old Elegnat Git configuration keys..."
-          , PrintText "==>> git config --local --unset elegant.acquired"
-          , PrintText "==========================="
-          , PrintText "== Configuring basics... =="
-          , PrintText "==========================="
-          , Prompt    "What is your user name?: test"
-          , PrintText "==>> git config --local user.name test"
-          , Prompt    "What is your email?: test"
-          , PrintText "==>> git config --local user.email test"
-          , Prompt    "What is the command to launching an editor?: test"
-          , PrintText "==>> git config --local core.editor test"
-          , Prompt    "What is the default branch? {master}: test"
-          , PrintText "==>> git config --local elegant-git.default-branch test"
-          , Prompt    "What are protected branches (split with space) {master}: test"
-          , PrintText "==>> git config --local elegant-git.protected-branches test"
+        , [ PrintText [s|=========================================|]
+          , PrintText [s|== Removing obsolete configurations... ==|]
+          , PrintText [s|=========================================|]
+          , PrintText [s|Removing old Elegnat Git configuration keys...|]
+          , PrintText [s|==>> git config --local --unset elegant.acquired|]
+          , PrintText [s|===========================|]
+          , PrintText [s|== Configuring basics... ==|]
+          , PrintText [s|===========================|]
+          , Prompt    [s|What is your user name?: test|]
+          , PrintText [s|==>> git config --local user.name "test"|]
+          , Prompt    [s|What is your email?: test|]
+          , PrintText [s|==>> git config --local user.email "test"|]
+          , Prompt    [s|What is the command to launching an editor?: test|]
+          , PrintText [s|==>> git config --local core.editor "test"|]
+          , Prompt    [s|What is the default branch? {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.default-branch "test"|]
+          , Prompt    [s|What are protected branches (split with space) {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.protected-branches "test"|]
           ]
          ++ standardsOutputBlock
          ++ aliasesOutputBlock
@@ -289,26 +291,26 @@ spec = do
 
       runGitActionPure git AcquireRepository.cmd `shouldBe`
         ( repoWithNewConfig
-        , [ PrintText "========================================="
-          , PrintText "== Removing obsolete configurations... =="
-          , PrintText "========================================="
-          , PrintText "Removing old Elegant Git aliases..."
-          , PrintText "==>> git config --local --unset alias.polish-work"
-          , PrintText "==>> git config --local --unset alias.polish-workflow"
-          , PrintText "==>> git config --local --unset alias.prune-repository"
-          , PrintText "==========================="
-          , PrintText "== Configuring basics... =="
-          , PrintText "==========================="
-          , Prompt    "What is your user name?: test"
-          , PrintText "==>> git config --local user.name test"
-          , Prompt    "What is your email?: test"
-          , PrintText "==>> git config --local user.email test"
-          , Prompt    "What is the command to launching an editor?: test"
-          , PrintText "==>> git config --local core.editor test"
-          , Prompt    "What is the default branch? {master}: test"
-          , PrintText "==>> git config --local elegant-git.default-branch test"
-          , Prompt    "What are protected branches (split with space) {master}: test"
-          , PrintText "==>> git config --local elegant-git.protected-branches test"
+        , [ PrintText [s|=========================================|]
+          , PrintText [s|== Removing obsolete configurations... ==|]
+          , PrintText [s|=========================================|]
+          , PrintText [s|Removing old Elegant Git aliases...|]
+          , PrintText [s|==>> git config --local --unset alias.polish-work|]
+          , PrintText [s|==>> git config --local --unset alias.polish-workflow|]
+          , PrintText [s|==>> git config --local --unset alias.prune-repository|]
+          , PrintText [s|===========================|]
+          , PrintText [s|== Configuring basics... ==|]
+          , PrintText [s|===========================|]
+          , Prompt    [s|What is your user name?: test|]
+          , PrintText [s|==>> git config --local user.name "test"|]
+          , Prompt    [s|What is your email?: test|]
+          , PrintText [s|==>> git config --local user.email "test"|]
+          , Prompt    [s|What is the command to launching an editor?: test|]
+          , PrintText [s|==>> git config --local core.editor "test"|]
+          , Prompt    [s|What is the default branch? {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.default-branch "test"|]
+          , Prompt    [s|What are protected branches (split with space) {master}: test|]
+          , PrintText [s|==>> git config --local elegant-git.protected-branches "test"|]
           ]
          ++ standardsOutputBlock
          ++ aliasesOutputBlock


### PR DESCRIPTION
There is an issue in how we test actions. Fundamentally, we rely on the fact that the `Real` runner is generating `git` calls correctly. This could be neglected in theory, but there is another issue, which forces us to generate "textual" representation of what our command is doing, in multiple places, which leads to code repetition.
As a solution to this, I've created 1 data type for every type of the command we can execute, and implemeted the way to render it to the "textual" representation.
This could be used by `Real` runner directly, but this still suffers from a different issue. We give `Real` runner to much access, by adding `MonadIO` to the context.
There is a solution however. We can create a custom `Monad` which can provide all needed functions for `Real` to proceed. Going this way, we can hide how we "render" and "execute" git calls from the `Real` runner, which implies that it has no way to run arbitrary commands at all.

Values to `git config` should be quoted to work properly, otherwise they
(specifically aliases) would be set as multi-value configs.

However, if we just blindly change this to be quoted values, we would
split them into separate arguments for a proc, which would lead to the
same issue.
To improve this, we just need to use `[]` instead of `Text` for command
args.

Note: I've switched to "raw strings" (`[s|quoted "string"|]`) in
`AcquireRepositorySpec.hs` to remove escaping of double quotes.

#299

The contribution:
- [ ] updates all affected documentation
- [ ] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [ ] updates the completion scripts if requires
- [ ] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
