### PR TITLE
Put `acquire-repository` in the right section

### DIFF
--- a/src/Elegit/Cli/Parser.hs
+++ b/src/Elegit/Cli/Parser.hs
@@ -15,12 +15,12 @@ dayToDayContributionsCommand :: Command ElegitCommand
 dayToDayContributionsCommand =
     commandGroup "make day-to-day contributions"
     <> ShowWork.cli
-    <> AcquireRepository.cli
 
 
 enableElegantGitServices :: Command ElegitCommand
 enableElegantGitServices =
     commandGroup "enable Elegant Git services"
+    <> AcquireRepository.cli
     <> InitRepository.cli
 
 


### PR DESCRIPTION
The `acquire-repository` must be located in the "enable Elegant Git services" sections.

The contribution:
- [ ] updates all affected documentation
- [x] provides commits messages which comply with the `CONTRIBUTING.md > Committing the changes` rules
- [x] updates the completion scripts if requires
- [x] complies with all requirements from `README.md > Hands-on development notes`

@bees-hive/elegant-git-maintainers, please review.
